### PR TITLE
feat(popup-menu): add resolver core with `PopupMenuNode` and `resolveNodeDefs`

### DIFF
--- a/packages/react/src/internal/popup-menu/resolve/__tests__/resolve.test.ts
+++ b/packages/react/src/internal/popup-menu/resolve/__tests__/resolve.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import type { NodeDef } from '../../deep-search/types.js'
+import { computeDefPath } from '../../deep-search/utils.js'
+import { resolveNodeDefs } from '../resolve.js'
+
+const item = (value: string, id?: string): NodeDef =>
+  ({ kind: 'item', value, id, render: () => null }) as NodeDef
+
+const submenu = (value: string, nodes: NodeDef[], id?: string): NodeDef =>
+  ({ kind: 'submenu', value, id, nodes, render: () => null }) as NodeDef
+
+describe('resolveNodeDefs', () => {
+  it('resolves flat items', () => {
+    const [node] = resolveNodeDefs([item('Apple')], null, [])
+
+    expect(node).toMatchObject({
+      segment: 'apple',
+      defPath: ['apple'],
+      id: 'apple',
+      depth: 0,
+      index: 0,
+      parent: null,
+    })
+  })
+
+  it('preserves explicit ids verbatim', () => {
+    const [node] = resolveNodeDefs([item('Apple', 'Custom ID!')], null, [])
+
+    expect(node).toMatchObject({
+      segment: 'Custom ID!',
+      defPath: ['Custom ID!'],
+      id: 'Custom ID!',
+    })
+  })
+
+  it('resolves submenu lineage', () => {
+    const [node] = resolveNodeDefs(
+      [submenu('Status', [item('Backlog')])],
+      null,
+      [],
+    )
+    const child = node.children[0]
+
+    expect(child).toMatchObject({
+      defPath: ['status', 'backlog'],
+      id: 'status.backlog',
+      parent: node,
+      depth: 1,
+    })
+  })
+
+  it('keeps groups path-transparent', () => {
+    const group = {
+      kind: 'group',
+      id: 'g1',
+      nodes: [item('Backlog')],
+    } as NodeDef
+    const [node] = resolveNodeDefs([group], null, [])
+    const child = node.children[0]
+
+    expect(node).toMatchObject({ id: 'g1', segment: 'g1', defPath: ['g1'] })
+    expect(child).toMatchObject({
+      defPath: ['backlog'],
+      id: 'backlog',
+      depth: 1,
+      parent: node,
+    })
+  })
+
+  it('keeps radio-groups path-transparent and uses their id as segment', () => {
+    const radioGroup = {
+      kind: 'radio-group',
+      id: 'rg1',
+      value: 'selected-value',
+      nodes: [{ kind: 'radio-item', value: 'Backlog', render: () => null }],
+    } as NodeDef
+    const [node] = resolveNodeDefs([radioGroup], null, [])
+    const child = node.children[0]
+
+    expect(node).toMatchObject({
+      segment: 'rg1',
+      id: 'rg1',
+      defPath: ['rg1'],
+    })
+    expect(child).toMatchObject({ defPath: ['backlog'], id: 'backlog' })
+  })
+
+  it('includes tree-item segments in descendant paths', () => {
+    const treeItem = {
+      kind: 'tree-item',
+      value: 'Fruits',
+      nodes: [item('Apple')],
+      render: () => null,
+    } as NodeDef
+    const [node] = resolveNodeDefs([treeItem], null, [])
+
+    expect(node.children[0]).toMatchObject({
+      defPath: ['fruits', 'apple'],
+      id: 'fruits.apple',
+    })
+  })
+
+  it('drops empty segments from paths', () => {
+    const [node] = resolveNodeDefs([submenu('⚙️', [item('Backlog')])], null, [])
+
+    expect(node).toMatchObject({ segment: '', defPath: [], id: '' })
+    expect(node.children[0]).toMatchObject({
+      defPath: ['backlog'],
+      id: 'backlog',
+    })
+  })
+
+  it('resolves id-less separators', () => {
+    const nodes = resolveNodeDefs(
+      [item('a'), { kind: 'separator' }, item('b')] as NodeDef[],
+      null,
+      [],
+    )
+
+    expect(nodes[1]).toMatchObject({ segment: '', id: '', index: 1 })
+  })
+
+  it('matches computeDefPath for nested contributing ancestors', () => {
+    const root = submenu('Status', [
+      submenu('Open Items', [item('Backlog')], 'open-items-id'),
+    ])
+    const leaf = resolveNodeDefs([root], null, [])[0].children[0].children[0]
+    const ancestorSegments = ['status', 'open-items-id']
+
+    expect(leaf.defPath).toEqual(
+      computeDefPath(ancestorSegments, [], undefined, 'Backlog'),
+    )
+  })
+})

--- a/packages/react/src/internal/popup-menu/resolve/resolve.ts
+++ b/packages/react/src/internal/popup-menu/resolve/resolve.ts
@@ -1,0 +1,72 @@
+import { slugify } from '../../listbox/utils/normalize.js'
+import type { NodeDef } from '../deep-search/types.js'
+import type { PopupMenuNode } from './types.js'
+
+/** Segment for a def: explicit `id` verbatim, else slugified `value`. */
+export function segmentForDef(def: NodeDef): string {
+  switch (def.kind) {
+    case 'group':
+    case 'radio-group':
+      return def.id
+    case 'separator':
+      return def.id ?? ''
+    default:
+      return def.id ?? slugify(def.value)
+  }
+}
+
+/** Child defs of a def, in def order; empty for leaf kinds. */
+export function childDefsOf(def: NodeDef): readonly NodeDef[] {
+  switch (def.kind) {
+    case 'group':
+    case 'radio-group':
+      return def.nodes
+    case 'submenu':
+    case 'subpage':
+    case 'tree-item':
+      return def.nodes ?? []
+    default:
+      return []
+  }
+}
+
+/** Kinds whose segment is part of their descendants' definition paths. */
+export function contributesPathSegment(def: NodeDef): boolean {
+  return (
+    def.kind === 'submenu' || def.kind === 'subpage' || def.kind === 'tree-item'
+  )
+}
+
+/**
+ * Resolve a def list into node instances under `parent`.
+ * `basePath` is the path segments contributed by ancestors (the parent's
+ * `defPath` when the parent contributes a segment, otherwise the parent's
+ * own base path); pass `[]` for roots.
+ */
+export function resolveNodeDefs(
+  defs: readonly NodeDef[],
+  parent: PopupMenuNode | null,
+  basePath: readonly string[],
+): PopupMenuNode[] {
+  return defs.map((def, index) => {
+    const segment = segmentForDef(def)
+    const defPath = segment ? [...basePath, segment] : [...basePath]
+    const node: PopupMenuNode = {
+      def,
+      kind: def.kind,
+      segment,
+      defPath,
+      id: def.id ?? defPath.join('.'),
+      parent,
+      children: [],
+      depth: parent ? parent.depth + 1 : 0,
+      index,
+    }
+    node.children = resolveNodeDefs(
+      childDefsOf(def),
+      node,
+      contributesPathSegment(def) ? node.defPath : basePath,
+    )
+    return node
+  })
+}

--- a/packages/react/src/internal/popup-menu/resolve/types.ts
+++ b/packages/react/src/internal/popup-menu/resolve/types.ts
@@ -1,0 +1,36 @@
+import type { NodeDef } from '../deep-search/types.js'
+
+/**
+ * A menu node: the library-created, resolved instance of a node def.
+ * Exactly one per logical row per menu root, in every render context —
+ * object identity is row identity, and `id` is its serialization.
+ * Created by resolution at the root or by grafting; instances are stable
+ * across content re-supplies (reconciliation swaps `def` in place).
+ */
+export interface PopupMenuNode {
+  /** The originating def. Replaced in place when content is re-supplied. */
+  def: NodeDef
+  /** Mirror of `def.kind`, stable for the node's lifetime. */
+  kind: NodeDef['kind']
+  /**
+   * This node's path component: explicit `def.id` verbatim when present,
+   * otherwise the slugified `value` (kinds without a display value use
+   * their required `id`; id-less separators have an empty segment).
+   */
+  segment: string
+  /**
+   * Definition path: segments from the menu root to this node, including
+   * its own segment, root-first. Only submenu, subpage, and tree-item
+   * ancestors contribute segments (groups and radio-groups are
+   * path-transparent). Empty segments are dropped.
+   */
+  defPath: string[]
+  /** Row id: `def.id` verbatim when present, else `defPath.join('.')`. */
+  id: string
+  parent: PopupMenuNode | null
+  children: PopupMenuNode[]
+  /** Def-tree depth counting every node kind; roots are 0. */
+  depth: number
+  /** Sibling index in the def tree (position within `parent.children`). */
+  index: number
+}


### PR DESCRIPTION
## Summary

Adds the resolver core for the data-first popup-menu system per ADR-0001: the canonical internal `PopupMenuNode` type and a pure `resolveNodeDefs` function that turns a `NodeDef[]` tree into node instances carrying identity (`segment`, `defPath`, `id`) and tree links (`parent`, `children`, `depth`, `index`). Pure module + unit tests — nothing imports it yet, zero behavior change, zero public API change.

## Changes

- New `packages/react/src/internal/popup-menu/resolve/types.ts` — `PopupMenuNode` with documented identity semantics (explicit `id` verbatim, else `defPath.join('.')`).
- New `packages/react/src/internal/popup-menu/resolve/resolve.ts` — `segmentForDef` (per-kind segment rules; `group`/`radio-group` use their required `id`, `RadioGroupDef.value` is never a segment), `childDefsOf`, `contributesPathSegment` (`submenu`/`subpage`/`tree-item` only — groups are path-transparent), and `resolveNodeDefs`.
- New unit tests (9 cases) including a parity test pinning resolver `defPath`s to the shipped `computeDefPath` string rule.

## Motivation

First slice of the resolved-menu-nodes stack (Linear project "Resolved menu nodes"): identity moves from per-render string composition to resolution-time node instances, so object identity can become row identity. #437 (reconcile + graft store) and #438 (root-owned mount) build directly on these exports. Nothing is exported from the publicly reachable `internal/popup-menu` barrel.

## Tests

`resolve.test.ts`: flat items, explicit id verbatim, submenu lineage, group and radio-group path transparency, tree-item contribution, empty-segment dropping (emoji value), id-less separators, and `computeDefPath` parity. Full gates: `bun run check`, `bun run type-check`, `bun run test --filter @bazza-ui/react` all green.

Closes [UI-455](https://linear.app/bazzalabs/issue/UI-455/add-resolver-core-popupmenunode-and-resolvenodedefs)
