### PR TITLE
feat(popup-menu): add `createMenuTreeResolver` with id-keyed reconcile and graft

### DIFF
--- a/packages/react/src/internal/popup-menu/resolve/__tests__/resolver.test.ts
+++ b/packages/react/src/internal/popup-menu/resolve/__tests__/resolver.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest'
+import type { NodeDef } from '../../deep-search/types.js'
+import { resolveNodeDefs } from '../resolve.js'
+import { createMenuTreeResolver } from '../resolver.js'
+
+const item = (value: string, id?: string): NodeDef =>
+  ({ kind: 'item', value, id, render: () => null }) as NodeDef
+
+const submenu = (value: string, nodes: NodeDef[], id?: string): NodeDef =>
+  ({ kind: 'submenu', value, id, nodes, render: () => null }) as NodeDef
+
+const group = (id: string, nodes: NodeDef[]): NodeDef =>
+  ({ kind: 'group', id, nodes }) as NodeDef
+
+describe('createMenuTreeResolver', () => {
+  it('initially resolves nested content and supports both lookups', () => {
+    const backlog = item('Backlog')
+    const status = submenu('Status', [backlog])
+    const resolver = createMenuTreeResolver()
+
+    resolver.setContent([status])
+
+    expect(resolver.rootNodes).toEqual(resolveNodeDefs([status], null, []))
+    expect(resolver.getNodeById('status.backlog')?.def).toBe(backlog)
+    expect(resolver.getNodeForDef(backlog)).toBe(
+      resolver.getNodeById('status.backlog'),
+    )
+  })
+
+  it('is idempotent when setContent receives the same array', () => {
+    const defs = [submenu('Status', [item('Backlog')]), item('Settings')]
+    const resolver = createMenuTreeResolver()
+    resolver.setContent(defs)
+    const before = [...resolver.rootNodes, ...resolver.rootNodes[0]!.children]
+
+    resolver.setContent(defs)
+
+    const after = [...resolver.rootNodes, ...resolver.rootNodes[0]!.children]
+    after.forEach((node, index) => {
+      expect(node).toBe(before[index])
+    })
+  })
+
+  it('preserves a same-kind duplicate id when a mixed-kind sibling appears', () => {
+    const resolver = createMenuTreeResolver()
+    const originalSubmenu = submenu('Sub', [item('Child')], 'x')
+    resolver.setContent([item('Old', 'x'), originalSubmenu])
+    const submenuNode = resolver.rootNodes[1]!
+
+    // The separator cannot match either existing node (kind mismatch), and
+    // must not consume the item candidate for id 'x' — the ref-equal submenu
+    // def must still match its surviving instance.
+    resolver.setContent([
+      { kind: 'separator', id: 'x' } as NodeDef,
+      originalSubmenu,
+    ])
+
+    expect(resolver.rootNodes[1]).toBe(submenuNode)
+  })
+
+  it('reconciles a fresh content tree by id while swapping defs', () => {
+    const oldBacklog = item('Backlog')
+    const oldStatus = submenu('Status', [oldBacklog])
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([oldStatus])
+    const oldStatusNode = resolver.rootNodes[0]!
+    const oldBacklogNode = oldStatusNode.children[0]!
+
+    const newBacklog = item('Backlog')
+    const newStatus = submenu('Status', [newBacklog])
+    resolver.setContent([newStatus])
+
+    expect(resolver.rootNodes[0]).toBe(oldStatusNode)
+    expect(oldStatusNode.children[0]).toBe(oldBacklogNode)
+    expect(oldStatusNode.def).toBe(newStatus)
+    expect(oldBacklogNode.def).toBe(newBacklog)
+    expect(resolver.getNodeForDef(oldBacklog)).toBeUndefined()
+    expect(resolver.getNodeForDef(newBacklog)).toBe(oldBacklogNode)
+  })
+
+  it('uses the reference fast path for an unchanged subtree', () => {
+    const stableChild = item('Stable child')
+    const stable = submenu('Stable', [stableChild])
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([stable, item('Other')])
+    const stableNode = resolver.rootNodes[0]!
+    const childNode = stableNode.children[0]!
+    const freshOther = item('Other')
+
+    resolver.setContent([stable, freshOther])
+
+    expect(resolver.rootNodes[0]).toBe(stableNode)
+    expect(stableNode.children[0]).toBe(childNode)
+    expect(resolver.rootNodes[1]!.def).toBe(freshOther)
+  })
+
+  it('adds, removes, and reorders nodes by id', () => {
+    const a = item('A')
+    const b = item('B')
+    const c = item('C')
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([a, b])
+    const aNode = resolver.getNodeForDef(a)!
+
+    const freshA = item('A')
+    resolver.setContent([c, freshA])
+
+    expect(resolver.getNodeForDef(b)).toBeUndefined()
+    expect(resolver.getNodeById('b')).toBeUndefined()
+    expect(resolver.getNodeForDef(a)).toBeUndefined()
+    expect(resolver.getNodeForDef(freshA)).toBe(aNode)
+    expect(resolver.getNodeForDef(c)).toBe(resolver.rootNodes[0])
+    expect(resolver.rootNodes.map((node) => node.def.value)).toEqual(['C', 'A'])
+    expect(resolver.rootNodes[1]).toBe(aNode)
+    expect(resolver.rootNodes.map((node) => node.index)).toEqual([0, 1])
+  })
+
+  it('cascades value renames but preserves explicit-id lineage', () => {
+    const oldChild = item('Backlog')
+    const old = submenu('Status', [oldChild])
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([old])
+    const oldNode = resolver.rootNodes[0]!
+
+    const renamedChild = item('Backlog')
+    resolver.setContent([submenu('Workflow', [renamedChild])])
+    expect(resolver.rootNodes[0]).not.toBe(oldNode)
+    expect(resolver.getNodeById('status.backlog')).toBeUndefined()
+    expect(resolver.getNodeById('workflow.backlog')?.def).toBe(renamedChild)
+
+    const explicitChild = item('Backlog')
+    const explicit = submenu('Status', [explicitChild], 'status-id')
+    resolver.setContent([explicit])
+    const explicitNode = resolver.rootNodes[0]!
+    const renamedExplicit = submenu('Workflow', [item('Backlog')], 'status-id')
+    resolver.setContent([renamedExplicit])
+    expect(resolver.rootNodes[0]).toBe(explicitNode)
+    expect(explicitNode.defPath).toEqual(['status-id'])
+    expect(explicitNode.children[0]!.defPath).toEqual(['status-id', 'backlog'])
+  })
+
+  it('pairwise re-matches duplicate sibling ids', () => {
+    const resolver = createMenuTreeResolver()
+    const first = item('Same')
+    const second = item('Same')
+    resolver.setContent([first, second])
+    const before = [...resolver.rootNodes]
+    const fresh = [item('Same'), item('Same')]
+    resolver.setContent(fresh)
+
+    expect(resolver.rootNodes[0]).toBe(before[0])
+    expect(resolver.rootNodes[1]).toBe(before[1])
+    expect(resolver.getNodeById('same')).toBe(before[0])
+  })
+
+  it('replaces a node when its kind changes at a stable id', () => {
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([item('Old', 'x')])
+    const oldNode = resolver.rootNodes[0]!
+    const replacement = submenu('New', [item('Child')], 'x')
+    resolver.setContent([replacement])
+
+    expect(resolver.rootNodes[0]).not.toBe(oldNode)
+    expect(resolver.rootNodes[0]!.kind).toBe('submenu')
+    expect(resolver.getNodeById('x')).toBe(resolver.rootNodes[0])
+  })
+
+  it('does not disturb grafts when a ref-equal node is reordered', () => {
+    const status = submenu('Status', [item('Backlog')])
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([status, item('Other')])
+    const statusNode = resolver.rootNodes[0]!
+    resolver.graft(statusNode, [statusNode.children[0]!.def, item('Extra')])
+    const extraNode = statusNode.children[1]!
+
+    resolver.setContent([item('Other'), status])
+
+    expect(statusNode.index).toBe(1)
+    expect(statusNode.children[1]).toBe(extraNode)
+  })
+
+  it('invalidates graft memo after content-driven reconciliation', () => {
+    const status = submenu('Status', [item('Backlog')])
+    const extra = item('Extra')
+    const graftDefs = [status.nodes![0]!, extra]
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([status])
+    const statusNode = resolver.rootNodes[0]!
+    resolver.graft(statusNode, graftDefs)
+    resolver.setContent([submenu('Status', [item('Backlog')])])
+    resolver.graft(resolver.rootNodes[0]!, graftDefs)
+
+    expect(resolver.rootNodes[0]!.children[1]!.id).toBe('status.extra')
+    expect(resolver.rootNodes[0]!.children[1]!.def).toBe(extra)
+  })
+
+  it('invalidates graft memo after ancestor graft reconciliation', () => {
+    const leaf = item('Leaf')
+    const extra = item('Extra')
+    const a = submenu('A', [submenu('B', [leaf])])
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([a])
+    const aNode = resolver.rootNodes[0]!
+    const bNode = aNode.children[0]!
+    const graftDefs = [leaf, extra]
+    resolver.graft(bNode, graftDefs)
+    resolver.graft(aNode, [submenu('B', [leaf])])
+    resolver.graft(bNode, graftDefs)
+
+    expect(bNode.children[1]!.id).toBe('a.b.extra')
+  })
+
+  it('grafts late children while preserving static children', () => {
+    const backlog = item('Backlog')
+    const status = submenu('Status', [backlog])
+    const inReview = item('In Review')
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([status])
+    const statusNode = resolver.rootNodes[0]!
+    const backlogNode = statusNode.children[0]!
+
+    resolver.graft(statusNode, [backlog, inReview])
+
+    expect(statusNode.children[0]).toBe(backlogNode)
+    expect(statusNode.children[1]).toMatchObject({
+      defPath: ['status', 'in-review'],
+      id: 'status.in-review',
+      parent: statusNode,
+      depth: statusNode.depth + 1,
+    })
+    expect(resolver.getNodeById('status.in-review')).toBe(
+      statusNode.children[1],
+    )
+  })
+
+  it('keeps grafts through a same-root setContent and trims on fresh content', () => {
+    const backlog = item('Backlog')
+    const inReview = item('In Review')
+    const root = [submenu('Status', [backlog])]
+    const resolver = createMenuTreeResolver()
+    resolver.setContent(root)
+    const statusNode = resolver.rootNodes[0]!
+    const graftDefs = [backlog, inReview]
+    resolver.graft(statusNode, graftDefs)
+    const grafted = statusNode.children[1]!
+    const childrenBefore = statusNode.children
+
+    // Same array reference → graft memo fast path (children array untouched).
+    resolver.graft(statusNode, graftDefs)
+    expect(statusNode.children).toBe(childrenBefore)
+    expect(statusNode.children[1]).toBe(grafted)
+    resolver.setContent(root)
+    expect(statusNode.children[1]).toBe(grafted)
+
+    resolver.setContent([submenu('Status', [item('Backlog')])])
+    expect(resolver.getNodeById('status.in-review')).toBeUndefined()
+    resolver.graft(resolver.rootNodes[0]!, [
+      resolver.rootNodes[0]!.children[0]!.def,
+      inReview,
+    ])
+    expect(resolver.rootNodes[0]!.children[1]).not.toBe(grafted)
+    expect(resolver.rootNodes[0]!.children[1]!.id).toBe('status.in-review')
+  })
+
+  it('uses the submenu base path when grafting under a transparent group', () => {
+    const status = submenu('Status', [group('group', [item('Static')])])
+    const late = item('Late')
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([status])
+    const groupNode = resolver.rootNodes[0]!.children[0]!
+
+    resolver.graft(groupNode, [groupNode.children[0]!.def, late])
+
+    expect(groupNode.children[1]!.defPath).toEqual(['status', 'late'])
+    expect(groupNode.children[1]!.id).toBe('status.late')
+  })
+})

--- a/packages/react/src/internal/popup-menu/resolve/resolver.ts
+++ b/packages/react/src/internal/popup-menu/resolve/resolver.ts
@@ -1,0 +1,162 @@
+import type { NodeDef } from '../deep-search/types.js'
+import {
+  childDefsOf,
+  contributesPathSegment,
+  resolveNodeDefs,
+  segmentForDef,
+} from './resolve.js'
+import type { PopupMenuNode } from './types.js'
+
+/**
+ * Owns the single resolved node tree for one menu root. Content may be
+ * re-supplied at any time (`setContent`) and late defs may be grafted under
+ * an already-resolved parent (`graft`); both reconcile by id with a
+ * reference fast path, so node instances are stable and repeat calls with
+ * identical arguments are no-ops.
+ */
+export interface MenuTreeResolver {
+  /** Current root nodes, in def order. */
+  readonly rootNodes: readonly PopupMenuNode[]
+  /** Re-supply the root def list and reconcile the whole tree. */
+  setContent(defs: readonly NodeDef[]): void
+  /**
+   * Resolve `defs` under `parent` (the graft point) and reconcile them
+   * against `parent.children`. `defs` is the parent's full child list
+   * from the graft source's perspective (static + late defs).
+   */
+  graft(parent: PopupMenuNode, defs: readonly NodeDef[]): void
+  /** Node whose current `def` is reference-equal to `def`, if any. */
+  getNodeForDef(def: NodeDef): PopupMenuNode | undefined
+  /** First registration wins; best-effort when ids collide. */
+  getNodeById(id: string): PopupMenuNode | undefined
+}
+
+export function createMenuTreeResolver(): MenuTreeResolver {
+  let rootNodes: PopupMenuNode[] = []
+  let lastRootDefs: readonly NodeDef[] | null = null
+  const defToNode = new Map<NodeDef, PopupMenuNode>()
+  const idToNode = new Map<string, PopupMenuNode>()
+  const lastGraftDefs = new WeakMap<PopupMenuNode, readonly NodeDef[]>()
+
+  const register = (node: PopupMenuNode): void => {
+    if (!defToNode.has(node.def)) defToNode.set(node.def, node)
+    if (!idToNode.has(node.id)) idToNode.set(node.id, node)
+    for (const child of node.children) register(child)
+  }
+
+  const retire = (node: PopupMenuNode): void => {
+    if (defToNode.get(node.def) === node) defToNode.delete(node.def)
+    if (idToNode.get(node.id) === node) idToNode.delete(node.id)
+    lastGraftDefs.delete(node)
+    for (const child of node.children) retire(child)
+  }
+
+  const samePath = (left: readonly string[], right: readonly string[]) =>
+    left.length === right.length &&
+    left.every((part, index) => part === right[index])
+
+  const baseOf = (node: PopupMenuNode): readonly string[] =>
+    contributesPathSegment(node.def)
+      ? node.defPath
+      : node.parent
+        ? baseOf(node.parent)
+        : []
+
+  const reconcile = (
+    existing: PopupMenuNode[],
+    defs: readonly NodeDef[],
+    parent: PopupMenuNode | null,
+    basePath: readonly string[],
+  ): PopupMenuNode[] => {
+    const buckets = new Map<string, PopupMenuNode[]>()
+    for (const node of existing) {
+      const bucket = buckets.get(node.id)
+      if (bucket) bucket.push(node)
+      else buckets.set(node.id, [node])
+    }
+
+    const matches: Array<PopupMenuNode | undefined> = []
+    const matched = new Set<PopupMenuNode>()
+    for (const def of defs) {
+      const segment = segmentForDef(def)
+      const defPath = segment ? [...basePath, segment] : [...basePath]
+      const id = def.id ?? defPath.join('.')
+      const bucket = buckets.get(id)
+      // Kind participates in matching (not just id): a kind mismatch must
+      // not consume the candidate, so a later same-kind def can still match.
+      const node = bucket?.find(
+        (candidate) => !matched.has(candidate) && candidate.kind === def.kind,
+      )
+      if (node) {
+        matched.add(node)
+        matches.push(node)
+      } else matches.push(undefined)
+    }
+
+    for (const node of existing) {
+      if (!matched.has(node)) retire(node)
+    }
+
+    return defs.map((def, index) => {
+      const node = matches[index]
+      const segment = segmentForDef(def)
+      const defPath = segment ? [...basePath, segment] : [...basePath]
+      const id = def.id ?? defPath.join('.')
+
+      if (!node) {
+        const created = resolveNodeDefs([def], parent, basePath)[0]!
+        created.index = index
+        register(created)
+        return created
+      }
+
+      if (node.def === def && samePath(node.defPath, defPath)) {
+        node.index = index
+        return node
+      }
+
+      if (defToNode.get(node.def) === node) defToNode.delete(node.def)
+      node.def = def
+      node.segment = segment
+      node.defPath = defPath
+      node.index = index
+      if (node.id !== id) {
+        if (idToNode.get(node.id) === node) idToNode.delete(node.id)
+        node.id = id
+        if (!idToNode.has(id)) idToNode.set(id, node)
+      }
+      if (!defToNode.has(def)) defToNode.set(def, node)
+
+      lastGraftDefs.delete(node)
+      node.children = reconcile(
+        node.children,
+        childDefsOf(def),
+        node,
+        contributesPathSegment(def) ? node.defPath : basePath,
+      )
+      return node
+    })
+  }
+
+  return {
+    get rootNodes() {
+      return rootNodes
+    },
+    setContent(defs) {
+      if (defs === lastRootDefs) return
+      rootNodes = reconcile(rootNodes, defs, null, [])
+      lastRootDefs = defs
+    },
+    graft(parent, defs) {
+      if (defs === lastGraftDefs.get(parent)) return
+      parent.children = reconcile(parent.children, defs, parent, baseOf(parent))
+      lastGraftDefs.set(parent, defs)
+    },
+    getNodeForDef(def) {
+      return defToNode.get(def)
+    },
+    getNodeById(id) {
+      return idToNode.get(id)
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Adds `createMenuTreeResolver()`: the per-menu-root store that owns the resolved node tree, reconciling re-supplied content by id with a reference fast path and grafting late-arriving defs under an already-resolved parent. Pure module + unit tests — still unimported by product code, zero behavior change.

## Changes

- New `packages/react/src/internal/popup-menu/resolve/resolver.ts` — `MenuTreeResolver` (`rootNodes`, `setContent`, `graft`, `getNodeForDef`, `getNodeById`) with: pairwise id-keyed child matching (kind participates in matching, so mixed-kind id collisions never steal a same-kind candidate), subtree reference fast path (index-only moves never descend, preserving grafts), retire-before-create ordering (kind changes at a stable id keep `getNodeById` correct), first-registration-wins maps with pointer-checked deletes, and graft-memo invalidation whenever any reconcile pass descends into a node's child level.
- New `resolver.test.ts` — 15 behavior tests: identity across structural re-supplies, fast paths (incl. same-reference graft no-op), add/remove/reorder, value-rename cascades vs explicit-id survival, duplicate sibling ids, kind change, graft lineage/persistence/trim-back, both graft-memo invalidation directions, transparent-parent (`group`) grafting, and mixed-kind duplicate-id preservation.

## Motivation

Object identity is row identity in the resolved-node model (ADR-0001), so instances must survive consumer re-renders that recreate def arrays — React-keys semantics at the def level. Graft is deliberately the same reconcile routine entered at a graft point: nested surfaces report their full merged child list, static children hit the fast path, async children join with correct lineage. Builds on #436; #438 mounts this store per menu root.

## Tests

15 unit tests in `resolver.test.ts` (see Changes). Full gates green: `bun run check`, `bun run type-check`, `bun run test --filter @bazza-ui/react`.

Closes [UI-456](https://linear.app/bazzalabs/issue/UI-456/add-createmenutreeresolver-with-reconcile-and-graft)
