### PR TITLE
feat(popup-menu): mount root-owned menu-tree resolution (inert)

### DIFF
--- a/.changeset/menu-tree-resolver.md
+++ b/.changeset/menu-tree-resolver.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': patch
+---
+
+Add an internal root-owned menu-tree resolver for data-first popup menus: node defs are resolved once per menu root into stable node instances, reconciled by id with a reference fast path, and late defs are grafted with correct lineage. Internal groundwork only — no public API or behavior change.

--- a/packages/react/src/internal/popup-menu/components/providers.tsx
+++ b/packages/react/src/internal/popup-menu/components/providers.tsx
@@ -10,6 +10,7 @@ import {
 } from '../contexts/component-name-context.js'
 import { FocusOwnerContext } from '../contexts/focus-owner-context.js'
 import { FocusZoneRegistryContext } from '../contexts/focus-zone-context.js'
+import { MenuTreeResolverContext } from '../contexts/menu-tree-resolver-context.js'
 import { OpenChainContext } from '../contexts/open-chain-context.js'
 import {
   PopupMenuContext,
@@ -30,6 +31,7 @@ import type {
   RowIdStrategy,
 } from '../deep-search/types.js'
 import { AimGuardProvider } from '../hooks/use-aim-guard.js'
+import { createMenuTreeResolver } from '../resolve/resolver.js'
 import type { FocusOwnerStore } from '../store/FocusOwnerStore.js'
 import { FocusZoneRegistry } from '../store/FocusZoneRegistry.js'
 import type { OpenChainStore } from '../store/OpenChainStore.js'
@@ -153,6 +155,13 @@ export function PopupMenuProviders(props: PopupMenuProvidersProps) {
     rowIdRegistryRef.current = createRowIdRegistry()
   }
 
+  const menuTreeResolverRef = React.useRef<ReturnType<
+    typeof createMenuTreeResolver
+  > | null>(null)
+  if (menuTreeResolverRef.current === null) {
+    menuTreeResolverRef.current = createMenuTreeResolver()
+  }
+
   // PopupMenu context value
   const popupMenuContextValue: PopupMenuContextValue = React.useMemo(
     () => ({
@@ -215,26 +224,28 @@ export function PopupMenuProviders(props: PopupMenuProvidersProps) {
   )
 
   return (
-    <RowIdRegistryContext.Provider value={rowIdRegistryRef.current}>
-      <ComponentNameContext.Provider value={componentName}>
-        <PopupMenuDebugContext.Provider value={popupMenuDebugContextValue}>
-          <PopupMenuContext.Provider value={popupMenuContextValue}>
-            <ListboxContextProvider.Provider value={listboxContextValue}>
-              <AimGuardProvider>
-                <FocusOwnerContext.Provider value={focusOwnerStore}>
-                  <OpenChainContext.Provider value={openChainStore}>
-                    <FocusZoneRegistryContext.Provider
-                      value={focusZoneRegistryRef.current}
-                    >
-                      {children}
-                    </FocusZoneRegistryContext.Provider>
-                  </OpenChainContext.Provider>
-                </FocusOwnerContext.Provider>
-              </AimGuardProvider>
-            </ListboxContextProvider.Provider>
-          </PopupMenuContext.Provider>
-        </PopupMenuDebugContext.Provider>
-      </ComponentNameContext.Provider>
-    </RowIdRegistryContext.Provider>
+    <MenuTreeResolverContext.Provider value={menuTreeResolverRef.current}>
+      <RowIdRegistryContext.Provider value={rowIdRegistryRef.current}>
+        <ComponentNameContext.Provider value={componentName}>
+          <PopupMenuDebugContext.Provider value={popupMenuDebugContextValue}>
+            <PopupMenuContext.Provider value={popupMenuContextValue}>
+              <ListboxContextProvider.Provider value={listboxContextValue}>
+                <AimGuardProvider>
+                  <FocusOwnerContext.Provider value={focusOwnerStore}>
+                    <OpenChainContext.Provider value={openChainStore}>
+                      <FocusZoneRegistryContext.Provider
+                        value={focusZoneRegistryRef.current}
+                      >
+                        {children}
+                      </FocusZoneRegistryContext.Provider>
+                    </OpenChainContext.Provider>
+                  </FocusOwnerContext.Provider>
+                </AimGuardProvider>
+              </ListboxContextProvider.Provider>
+            </PopupMenuContext.Provider>
+          </PopupMenuDebugContext.Provider>
+        </ComponentNameContext.Provider>
+      </RowIdRegistryContext.Provider>
+    </MenuTreeResolverContext.Provider>
   )
 }

--- a/packages/react/src/internal/popup-menu/contexts/graft-point-context.ts
+++ b/packages/react/src/internal/popup-menu/contexts/graft-point-context.ts
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import type { PopupMenuNode } from '../resolve/types.js'
+
+/** The enclosing submenu's resolved node — the graft point a nested data Surface attaches its content under. Null at the popup root and wherever the enclosing branch is not part of a resolved tree. */
+const GraftPointContext = React.createContext<PopupMenuNode | null>(null)
+
+export function useGraftPoint(): PopupMenuNode | null {
+  return React.useContext(GraftPointContext)
+}
+
+export { GraftPointContext }

--- a/packages/react/src/internal/popup-menu/contexts/menu-tree-resolver-context.ts
+++ b/packages/react/src/internal/popup-menu/contexts/menu-tree-resolver-context.ts
@@ -1,0 +1,12 @@
+import * as React from 'react'
+import type { MenuTreeResolver } from '../resolve/resolver.js'
+
+const MenuTreeResolverContext = React.createContext<MenuTreeResolver | null>(
+  null,
+)
+
+export function useMenuTreeResolver(): MenuTreeResolver | null {
+  return React.useContext(MenuTreeResolverContext)
+}
+
+export { MenuTreeResolverContext }

--- a/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
@@ -1,14 +1,24 @@
 'use client'
 
 import * as React from 'react'
-import type { useSurfaceContext } from '../../listbox/index.js'
+import {
+  useListboxContext,
+  type useSurfaceContext,
+} from '../../listbox/index.js'
 import { normalizeValue, slugify } from '../../listbox/utils/normalize.js'
 import { PopupMenuGroupLabel } from '../components/group-label/group-label.js'
 import {
   PopupMenuListPrimitive,
   type PopupMenuListProps,
 } from '../components/list/list.js'
+import {
+  GraftPointContext,
+  useGraftPoint,
+} from '../contexts/graft-point-context.js'
+import { useMenuTreeResolver } from '../contexts/menu-tree-resolver-context.js'
 import { useRowIdRegistry } from '../contexts/row-id-registry-context.js'
+import { useMaybeSubpageContext } from '../contexts/subpage-context.js'
+import { useMaybeSubpageStack } from '../contexts/subpage-stack-context.js'
 import {
   type AsyncMenuState,
   useAsyncMenuCoordinator,
@@ -651,6 +661,18 @@ export const DataListInner = React.forwardRef<
   const displayPath = useDisplayPath()
   const rowIdRegistry = useRowIdRegistry()
   const surfaceKey = React.useId()
+  const resolver = useMenuTreeResolver()
+  const graftParent = useGraftPoint()
+  const { depth: surfaceDepth } = useListboxContext()
+  const resolverSubpageContext = useMaybeSubpageContext()
+  const resolverSubpageStack = useMaybeSubpageStack()
+  // Mirrors surface.tsx's isSubpageSurfaceInThisPopup: a data surface
+  // rendered as a subpage of this popup must never feed resolution.
+  const isSubpageSurface = Boolean(
+    resolverSubpageContext &&
+      resolverSubpageStack?.getSurfaceId(resolverSubpageContext.pageId),
+  )
+  const isResolutionRoot = surfaceDepth === 0 && !isSubpageSurface
 
   // Get coordinator for async state
   const coordinator = useAsyncMenuCoordinator()
@@ -697,6 +719,26 @@ export const DataListInner = React.forwardRef<
     // For root-level DataSurface without asyncContent, append to static content
     return [...mergedContent, ...rootAsyncData.nodes]
   }, [mergedContent, asyncNodes, asyncContent])
+
+  // Feed root-owned resolution (inert in this stack: nothing renders from
+  // the resolved tree yet). setContent/graft are idempotent with reference
+  // fast paths, so render-time calls (incl. StrictMode re-invocations) are
+  // safe and cheap when content is unchanged. Subpage surfaces never feed:
+  // their rows already belong to the root surface's def tree.
+  React.useMemo(() => {
+    if (!resolver || isSubpageSurface) return
+    if (graftParent) {
+      resolver.graft(graftParent, contentWithRootAsync)
+    } else if (isResolutionRoot) {
+      resolver.setContent(contentWithRootAsync)
+    }
+  }, [
+    resolver,
+    graftParent,
+    isSubpageSurface,
+    isResolutionRoot,
+    contentWithRootAsync,
+  ])
 
   const streamOrderRef = React.useRef<{
     query: string
@@ -1141,24 +1183,28 @@ export const DataListInner = React.forwardRef<
 
         return (
           <ExtendDisplayPath key={compositeId} segment={submenuSegment}>
-            {node.render({
-              props: {
-                id: compositeId,
-                value: node.value,
-                disabled: node.disabled ?? false,
-                forceOrder: node.forceOrder,
-                forceScore: node.forceScore,
-              },
-              context: {
-                ...context,
-                value: node.value,
-                disabled: node.disabled ?? false,
-                async: submenuAsyncState,
-              },
-              nodes: staticNodes,
-              asyncContent: node.asyncNodes,
-              renderNode: submenuRenderNode,
-            })}
+            <GraftPointContext.Provider
+              value={resolver?.getNodeForDef(node) ?? null}
+            >
+              {node.render({
+                props: {
+                  id: compositeId,
+                  value: node.value,
+                  disabled: node.disabled ?? false,
+                  forceOrder: node.forceOrder,
+                  forceScore: node.forceScore,
+                },
+                context: {
+                  ...context,
+                  value: node.value,
+                  disabled: node.disabled ?? false,
+                  async: submenuAsyncState,
+                },
+                nodes: staticNodes,
+                asyncContent: node.asyncNodes,
+                renderNode: submenuRenderNode,
+              })}
+            </GraftPointContext.Provider>
           </ExtendDisplayPath>
         )
       }
@@ -1196,6 +1242,7 @@ export const DataListInner = React.forwardRef<
       isLegacyRowIdDefault,
       displayPath,
       isDeepSearching,
+      resolver,
     ],
   )
 

--- a/packages/react/src/internal/popup-menu/resolve/__tests__/mount.test.tsx
+++ b/packages/react/src/internal/popup-menu/resolve/__tests__/mount.test.tsx
@@ -1,0 +1,250 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { DropdownMenu } from '../../../../dropdown-menu/index.js'
+import { useMenuTreeResolver } from '../../contexts/menu-tree-resolver-context.js'
+import type { ItemDef, NodeDef, SubmenuDef } from '../../deep-search/types.js'
+import type { MenuTreeResolver } from '../resolver.js'
+
+function item(value: string): ItemDef {
+  return {
+    kind: 'item',
+    value,
+    render: ({ props }) => (
+      <DropdownMenu.Item {...props}>{value}</DropdownMenu.Item>
+    ),
+  }
+}
+
+function Rows() {
+  const { nodes, renderNode } = DropdownMenu.useDataList()
+  return <>{nodes.map(renderNode)}</>
+}
+
+function Probe({
+  onResolver,
+}: {
+  onResolver: (value: MenuTreeResolver) => void
+}) {
+  const resolver = useMenuTreeResolver()
+  if (resolver) onResolver(resolver)
+  return null
+}
+
+function Menu({
+  content,
+  onResolver,
+  search = false,
+}: {
+  content: NodeDef[]
+  onResolver: (value: MenuTreeResolver) => void
+  search?: boolean
+}) {
+  return (
+    <DropdownMenu.Root defaultOpen>
+      <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
+      <Probe onResolver={onResolver} />
+      <DropdownMenu.Portal>
+        <DropdownMenu.Positioner>
+          <DropdownMenu.Popup>
+            <DropdownMenu.Surface
+              content={content}
+              deepSearch={search ? { enabled: true, minLength: 0 } : undefined}
+            >
+              {search && <DropdownMenu.Input aria-label="Search" />}
+              <DropdownMenu.List>
+                <Rows />
+              </DropdownMenu.List>
+            </DropdownMenu.Surface>
+          </DropdownMenu.Popup>
+        </DropdownMenu.Positioner>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
+function submenu(
+  value: string,
+  nodes: NodeDef[],
+  nestedContent: NodeDef[] | (() => NodeDef[]),
+): SubmenuDef {
+  return {
+    kind: 'submenu',
+    value,
+    nodes,
+    render: ({ props, context }) => (
+      <DropdownMenu.Submenu>
+        <DropdownMenu.SubmenuTrigger {...props}>
+          {context.value}
+        </DropdownMenu.SubmenuTrigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Positioner>
+            <DropdownMenu.Popup>
+              <DropdownMenu.Surface
+                content={
+                  typeof nestedContent === 'function'
+                    ? nestedContent()
+                    : nestedContent
+                }
+              >
+                <DropdownMenu.List>
+                  <Rows />
+                </DropdownMenu.List>
+              </DropdownMenu.Surface>
+            </DropdownMenu.Popup>
+          </DropdownMenu.Positioner>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Submenu>
+    ),
+  }
+}
+
+describe('mounted menu-tree resolution', () => {
+  it('resolves root content with qualified definition paths', async () => {
+    let resolver!: MenuTreeResolver
+    render(
+      <Menu
+        onResolver={(value) => {
+          resolver = value
+        }}
+        content={[
+          item('Settings'),
+          submenu('Status', [item('Backlog'), item('In Progress')], []),
+        ]}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(resolver.getNodeById('status.backlog')).toBeDefined(),
+    )
+    const node = resolver.getNodeById('status.backlog')!
+    expect(node.defPath).toEqual(['status', 'backlog'])
+    expect(node.parent?.id).toBe('status')
+    expect(resolver.rootNodes).toHaveLength(2)
+  })
+
+  it('keeps node instances stable across recreated content', async () => {
+    let resolver!: MenuTreeResolver
+    const content = () => [
+      item('Settings'),
+      submenu('Status', [item('Backlog'), item('In Progress')], []),
+    ]
+    const view = render(
+      <Menu
+        onResolver={(value) => {
+          resolver = value
+        }}
+        content={content()}
+      />,
+    )
+    await waitFor(() =>
+      expect(resolver.getNodeById('status.backlog')).toBeDefined(),
+    )
+    const before = resolver.getNodeById('status.backlog')
+    view.rerender(
+      <Menu
+        onResolver={(value) => {
+          resolver = value
+        }}
+        content={content()}
+      />,
+    )
+    expect(resolver.getNodeById('status.backlog')).toBe(before)
+  })
+
+  it('grafts nested-surface defs outside the static def tree', async () => {
+    let resolver!: MenuTreeResolver
+    const leaf = item('Leaf')
+    const extra = item('Extra')
+    const content = [submenu('A', [leaf], [leaf, extra])]
+    const user = userEvent.setup()
+    render(
+      <Menu
+        onResolver={(value) => {
+          resolver = value
+        }}
+        content={content}
+      />,
+    )
+    await waitFor(() => expect(resolver.getNodeById('a.extra')).toBeUndefined())
+    await user.click(screen.getByRole('menuitem', { name: 'A' }))
+    await waitFor(() => expect(resolver.getNodeById('a.extra')).toBeDefined())
+    const parent = resolver.getNodeById('a')!
+    expect(resolver.getNodeById('a.extra')?.parent).toBe(parent)
+    expect(resolver.getNodeById('a.extra')?.defPath).toEqual(['a', 'extra'])
+    expect(parent.children.filter((node) => node.id === 'a.leaf')).toHaveLength(
+      1,
+    )
+  })
+
+  it('grafts late defs without replacing stable siblings', async () => {
+    let resolver!: MenuTreeResolver
+    const leaf = item('Leaf')
+    const late = item('Late')
+    const user = userEvent.setup()
+    let nestedContent: NodeDef[] = [leaf]
+    const submenuDef = submenu('A', [leaf], () => nestedContent)
+    const view = render(
+      <Menu
+        onResolver={(value) => {
+          resolver = value
+        }}
+        content={[submenuDef]}
+      />,
+    )
+    await user.click(screen.getByRole('menuitem', { name: 'A' }))
+    await waitFor(() => expect(resolver.getNodeById('a.leaf')).toBeDefined())
+    const before = resolver.getNodeById('a.leaf')
+    nestedContent = [leaf, late]
+    view.rerender(
+      <Menu
+        onResolver={(value) => {
+          resolver = value
+        }}
+        content={[submenuDef]}
+      />,
+    )
+    await user.click(screen.getByRole('menuitem', { name: 'A' }))
+    await waitFor(() => expect(resolver.getNodeById('a.late')).toBeDefined())
+    expect(resolver.getNodeById('a.leaf')).toBe(before)
+  })
+
+  it('preserves browse row ids', async () => {
+    render(
+      <Menu
+        onResolver={() => {}}
+        content={[item('Apple'), submenu('Status', [item('Backlog')], [])]}
+      />,
+    )
+    await waitFor(() =>
+      expect(screen.getByRole('option', { name: 'Apple' })).toHaveAttribute(
+        'id',
+        'apple',
+      ),
+    )
+    expect(screen.getByRole('menuitem', { name: 'Status' })).toHaveAttribute(
+      'id',
+      'status',
+    )
+  })
+
+  it('preserves deep-search row ids', async () => {
+    const user = userEvent.setup()
+    render(
+      <Menu
+        onResolver={() => {}}
+        search
+        content={[item('Apple'), submenu('Status', [item('Backlog')], [])]}
+      />,
+    )
+    await user.type(screen.getByRole('combobox', { name: 'Search' }), 'back')
+    // A deep-search result surfaced from inside the submenu keeps its
+    // path-qualified id — the pre-resolver expectation, unchanged.
+    await waitFor(() =>
+      expect(screen.getByRole('option', { name: 'Backlog' })).toHaveAttribute(
+        'id',
+        'status.backlog',
+      ),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Mounts root-owned menu-tree resolution: one `MenuTreeResolver` per menu root, fed live from the data-list pipeline — the popup's root data surface re-supplies its merged content, and nested data Surfaces graft their content under the enclosing submenu's resolved node via a new `GraftPointContext`. Completely inert: nothing renders, no event, no id computation reads the resolved tree yet. Zero behavior change (all 917 existing tests untouched and green).

## Changes

- `components/providers.tsx` — per-root `createMenuTreeResolver()` lazy-init (not dev-only) + outermost `MenuTreeResolverContext.Provider`.
- `deep-search/data-list.tsx` — `DataListInner` computes its resolution role internally (`useListboxContext().depth`, subpage context/stack hooks → `isSubpageSurface`, `isResolutionRoot`); a render-time feed `useMemo` after the merged-content memos calls `graft(graftParent, contentWithRootAsync)` or `setContent(contentWithRootAsync)`; `GraftPointContext.Provider` wraps the submenu `render` inside `ExtendDisplayPath` (looked up via `getNodeForDef`); `resolver` added to `renderRowNode`'s deps.
- New internal contexts `menu-tree-resolver-context.ts` / `graft-point-context.ts` (thin createContext + hook, per the row-id-registry exemplar).
- New `resolve/__tests__/mount.test.tsx` (6 integration tests) + `patch` changeset.

## Motivation

Completes the resolver-module stack (builds on #436, #437): the resolved node tree is now live per menu root so the follow-on stacks can route identity through `getRowId(node)` and swap render params to carry nodes. Role flags are computed inside `DataListInner` deliberately — `DataSurfaceContextValue` is re-exported through the public `internal/popup-menu` barrel and must not change shape. Subpage surfaces never feed (they would otherwise graft subpage children over the enclosing branch); `depth === 0` uniquely identifies the root surface because submenu roots re-provide the listbox context with incremented depth.

## Tests

`mount.test.tsx`: root resolution with qualified `defPath`s, instance stability across structurally recreated content, nested-Surface graft of a def **outside** the static def tree (isolates the graft path), late-def graft with stable siblings, and browse + deep-search zero-behavior assertions on rendered DOM row ids (the deep-search case types a query and asserts the flattened result keeps `status.backlog`). Full gates green: `bun run check`, `bun run type-check`, `bun run test --filter @bazza-ui/react` (917 tests).

Closes [UI-457](https://linear.app/bazzalabs/issue/UI-457/mount-root-owned-menu-tree-resolution-inert)
