### PR TITLE
feat(popup-menu): route resolver node ids through a `getRowId` seam

### DIFF
--- a/packages/react/src/internal/popup-menu/resolve/__tests__/resolve.test.ts
+++ b/packages/react/src/internal/popup-menu/resolve/__tests__/resolve.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { NodeDef } from '../../deep-search/types.js'
 import { computeDefPath } from '../../deep-search/utils.js'
-import { resolveNodeDefs } from '../resolve.js'
+import { defaultGetRowId, resolveNodeDefs } from '../resolve.js'
 
 const item = (value: string, id?: string): NodeDef =>
   ({ kind: 'item', value, id, render: () => null }) as NodeDef
@@ -11,7 +11,7 @@ const submenu = (value: string, nodes: NodeDef[], id?: string): NodeDef =>
 
 describe('resolveNodeDefs', () => {
   it('resolves flat items', () => {
-    const [node] = resolveNodeDefs([item('Apple')], null, [])
+    const [node] = resolveNodeDefs([item('Apple')], null, [], defaultGetRowId)
 
     expect(node).toMatchObject({
       segment: 'apple',
@@ -24,7 +24,12 @@ describe('resolveNodeDefs', () => {
   })
 
   it('preserves explicit ids verbatim', () => {
-    const [node] = resolveNodeDefs([item('Apple', 'Custom ID!')], null, [])
+    const [node] = resolveNodeDefs(
+      [item('Apple', 'Custom ID!')],
+      null,
+      [],
+      defaultGetRowId,
+    )
 
     expect(node).toMatchObject({
       segment: 'Custom ID!',
@@ -38,6 +43,7 @@ describe('resolveNodeDefs', () => {
       [submenu('Status', [item('Backlog')])],
       null,
       [],
+      defaultGetRowId,
     )
     const child = node.children[0]
 
@@ -55,7 +61,7 @@ describe('resolveNodeDefs', () => {
       id: 'g1',
       nodes: [item('Backlog')],
     } as NodeDef
-    const [node] = resolveNodeDefs([group], null, [])
+    const [node] = resolveNodeDefs([group], null, [], defaultGetRowId)
     const child = node.children[0]
 
     expect(node).toMatchObject({ id: 'g1', segment: 'g1', defPath: ['g1'] })
@@ -74,7 +80,7 @@ describe('resolveNodeDefs', () => {
       value: 'selected-value',
       nodes: [{ kind: 'radio-item', value: 'Backlog', render: () => null }],
     } as NodeDef
-    const [node] = resolveNodeDefs([radioGroup], null, [])
+    const [node] = resolveNodeDefs([radioGroup], null, [], defaultGetRowId)
     const child = node.children[0]
 
     expect(node).toMatchObject({
@@ -92,7 +98,7 @@ describe('resolveNodeDefs', () => {
       nodes: [item('Apple')],
       render: () => null,
     } as NodeDef
-    const [node] = resolveNodeDefs([treeItem], null, [])
+    const [node] = resolveNodeDefs([treeItem], null, [], defaultGetRowId)
 
     expect(node.children[0]).toMatchObject({
       defPath: ['fruits', 'apple'],
@@ -101,7 +107,12 @@ describe('resolveNodeDefs', () => {
   })
 
   it('drops empty segments from paths', () => {
-    const [node] = resolveNodeDefs([submenu('⚙️', [item('Backlog')])], null, [])
+    const [node] = resolveNodeDefs(
+      [submenu('⚙️', [item('Backlog')])],
+      null,
+      [],
+      defaultGetRowId,
+    )
 
     expect(node).toMatchObject({ segment: '', defPath: [], id: '' })
     expect(node.children[0]).toMatchObject({
@@ -115,6 +126,7 @@ describe('resolveNodeDefs', () => {
       [item('a'), { kind: 'separator' }, item('b')] as NodeDef[],
       null,
       [],
+      defaultGetRowId,
     )
 
     expect(nodes[1]).toMatchObject({ segment: '', id: '', index: 1 })
@@ -124,7 +136,8 @@ describe('resolveNodeDefs', () => {
     const root = submenu('Status', [
       submenu('Open Items', [item('Backlog')], 'open-items-id'),
     ])
-    const leaf = resolveNodeDefs([root], null, [])[0].children[0].children[0]
+    const leaf = resolveNodeDefs([root], null, [], defaultGetRowId)[0]
+      .children[0].children[0]
     const ancestorSegments = ['status', 'open-items-id']
 
     expect(leaf.defPath).toEqual(

--- a/packages/react/src/internal/popup-menu/resolve/__tests__/resolver.test.ts
+++ b/packages/react/src/internal/popup-menu/resolve/__tests__/resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { NodeDef } from '../../deep-search/types.js'
-import { resolveNodeDefs } from '../resolve.js'
+import { defaultGetRowId, resolveNodeDefs } from '../resolve.js'
 import { createMenuTreeResolver } from '../resolver.js'
 
 const item = (value: string, id?: string): NodeDef =>
@@ -20,7 +20,9 @@ describe('createMenuTreeResolver', () => {
 
     resolver.setContent([status])
 
-    expect(resolver.rootNodes).toEqual(resolveNodeDefs([status], null, []))
+    expect(resolver.rootNodes).toEqual(
+      resolveNodeDefs([status], null, [], defaultGetRowId),
+    )
     expect(resolver.getNodeById('status.backlog')?.def).toBe(backlog)
     expect(resolver.getNodeForDef(backlog)).toBe(
       resolver.getNodeById('status.backlog'),
@@ -273,5 +275,109 @@ describe('createMenuTreeResolver', () => {
 
     expect(groupNode.children[1]!.defPath).toEqual(['status', 'late'])
     expect(groupNode.children[1]!.id).toBe('status.late')
+  })
+})
+
+describe('getRowId seam', () => {
+  it('custom seam shapes ids', () => {
+    const resolver = createMenuTreeResolver({
+      getRowId: (node) => node.defPath.join('/') || node.def.id || '',
+    })
+    resolver.setContent([submenu('Status', [item('Backlog')])])
+
+    expect(resolver.getNodeById('status/backlog')).toBeDefined()
+    expect(resolver.getNodeById('status.backlog')).toBeUndefined()
+  })
+
+  it('matching agrees with the seam', () => {
+    const resolver = createMenuTreeResolver({
+      getRowId: (node) => node.defPath.join('/') || node.def.id || '',
+    })
+    resolver.setContent([submenu('Status', [item('Backlog')])])
+    const statusNode = resolver.rootNodes[0]!
+    const backlogNode = statusNode.children[0]!
+
+    resolver.setContent([submenu('Status', [item('Backlog')])])
+
+    expect(resolver.rootNodes[0]).toBe(statusNode)
+    expect(resolver.rootNodes[0]!.children[0]).toBe(backlogNode)
+  })
+
+  it('seam receives definitional facts', () => {
+    const captures: Array<{
+      node: Record<string, unknown>
+      hasId: boolean
+    }> = []
+    const resolver = createMenuTreeResolver({
+      getRowId: (node) => {
+        if (node.parent) {
+          captures.push({ node: { ...node }, hasId: 'id' in node })
+        }
+        return node.defPath.join('.')
+      },
+    })
+    resolver.setContent([submenu('Status', [item('Backlog')])])
+    const capture = captures[0]!
+    const parent = resolver.rootNodes[0]!
+
+    expect(capture.node).toMatchObject({
+      def: parent.children[0]!.def,
+      segment: 'backlog',
+      defPath: ['status', 'backlog'],
+      parent,
+      depth: 1,
+      index: 0,
+    })
+    expect(capture.hasId).toBe(false)
+  })
+
+  it('index-dependent seam is stable', () => {
+    const resolver = createMenuTreeResolver({
+      getRowId: (node) => `${node.defPath.join('.')}#${node.index}`,
+    })
+    resolver.setContent([item('First'), item('Second')])
+    const before = [...resolver.rootNodes]
+
+    expect(resolver.rootNodes.map((node) => node.id)).toEqual([
+      'first#0',
+      'second#1',
+    ])
+
+    resolver.setContent([item('First'), item('Second')])
+
+    expect(resolver.rootNodes[0]).toBe(before[0])
+    expect(resolver.rootNodes[1]).toBe(before[1])
+  })
+
+  it('default parity', () => {
+    const explicit = item('Ignored', 'explicit')
+    const explicitProbe = {
+      def: explicit,
+      kind: explicit.kind,
+      segment: 'explicit',
+      defPath: ['different'],
+      parent: null,
+      children: [],
+      depth: 0,
+      index: 0,
+    }
+    const idless = item('Ignored')
+    const idlessProbe = {
+      def: idless,
+      kind: idless.kind,
+      segment: 'ignored',
+      defPath: ['path', 'ignored'],
+      parent: null,
+      children: [],
+      depth: 0,
+      index: 0,
+    }
+
+    expect(defaultGetRowId(explicitProbe)).toBe(
+      explicit.id ?? explicitProbe.defPath.join('.'),
+    )
+    expect(defaultGetRowId(idlessProbe)).toBe(
+      idless.id ?? idlessProbe.defPath.join('.'),
+    )
   })
 })

--- a/packages/react/src/internal/popup-menu/resolve/resolve.ts
+++ b/packages/react/src/internal/popup-menu/resolve/resolve.ts
@@ -1,6 +1,15 @@
 import { slugify } from '../../listbox/utils/normalize.js'
 import type { NodeDef } from '../deep-search/types.js'
-import type { PopupMenuNode } from './types.js'
+import type {
+  GetRowIdFn,
+  PopupMenuNode,
+  UnidentifiedMenuNode,
+} from './types.js'
+
+/** Default row id: explicit `def.id` verbatim, else the joined definition path. */
+export function defaultGetRowId(node: UnidentifiedMenuNode): string {
+  return node.def.id ?? node.defPath.join('.')
+}
 
 /** Segment for a def: explicit `id` verbatim, else slugified `value`. */
 export function segmentForDef(def: NodeDef): string {
@@ -47,25 +56,31 @@ export function resolveNodeDefs(
   defs: readonly NodeDef[],
   parent: PopupMenuNode | null,
   basePath: readonly string[],
+  getRowId: GetRowIdFn,
 ): PopupMenuNode[] {
   return defs.map((def, index) => {
     const segment = segmentForDef(def)
     const defPath = segment ? [...basePath, segment] : [...basePath]
-    const node: PopupMenuNode = {
+    const unidentified: UnidentifiedMenuNode = {
       def,
       kind: def.kind,
       segment,
       defPath,
-      id: def.id ?? defPath.join('.'),
       parent,
       children: [],
       depth: parent ? parent.depth + 1 : 0,
       index,
     }
+    // Call the seam before spreading so the node reflects any reads the seam
+    // performs on the final definitional facts (spread-then-call would copy
+    // the fields before the seam runs).
+    const id = getRowId(unidentified)
+    const node: PopupMenuNode = { ...unidentified, id }
     node.children = resolveNodeDefs(
       childDefsOf(def),
       node,
       contributesPathSegment(def) ? node.defPath : basePath,
+      getRowId,
     )
     return node
   })

--- a/packages/react/src/internal/popup-menu/resolve/resolver.ts
+++ b/packages/react/src/internal/popup-menu/resolve/resolver.ts
@@ -2,10 +2,15 @@ import type { NodeDef } from '../deep-search/types.js'
 import {
   childDefsOf,
   contributesPathSegment,
+  defaultGetRowId,
   resolveNodeDefs,
   segmentForDef,
 } from './resolve.js'
-import type { PopupMenuNode } from './types.js'
+import type {
+  GetRowIdFn,
+  PopupMenuNode,
+  UnidentifiedMenuNode,
+} from './types.js'
 
 /**
  * Owns the single resolved node tree for one menu root. Content may be
@@ -31,7 +36,37 @@ export interface MenuTreeResolver {
   getNodeById(id: string): PopupMenuNode | undefined
 }
 
-export function createMenuTreeResolver(): MenuTreeResolver {
+export interface MenuTreeResolverOptions {
+  /** Row-id seam; defaults to `defaultGetRowId`. */
+  getRowId?: GetRowIdFn
+}
+
+function prospectiveIdentity(
+  def: NodeDef,
+  parent: PopupMenuNode | null,
+  basePath: readonly string[],
+  index: number,
+  getRowId: GetRowIdFn,
+): { segment: string; defPath: string[]; id: string } {
+  const segment = segmentForDef(def)
+  const defPath = segment ? [...basePath, segment] : [...basePath]
+  const probe: UnidentifiedMenuNode = {
+    def,
+    kind: def.kind,
+    segment,
+    defPath,
+    parent,
+    children: [],
+    depth: parent ? parent.depth + 1 : 0,
+    index,
+  }
+  return { segment, defPath, id: getRowId(probe) }
+}
+
+export function createMenuTreeResolver(
+  options: MenuTreeResolverOptions = {},
+): MenuTreeResolver {
+  const getRowId = options.getRowId ?? defaultGetRowId
   let rootNodes: PopupMenuNode[] = []
   let lastRootDefs: readonly NodeDef[] | null = null
   const defToNode = new Map<NodeDef, PopupMenuNode>()
@@ -77,10 +112,8 @@ export function createMenuTreeResolver(): MenuTreeResolver {
 
     const matches: Array<PopupMenuNode | undefined> = []
     const matched = new Set<PopupMenuNode>()
-    for (const def of defs) {
-      const segment = segmentForDef(def)
-      const defPath = segment ? [...basePath, segment] : [...basePath]
-      const id = def.id ?? defPath.join('.')
+    for (const [index, def] of defs.entries()) {
+      const { id } = prospectiveIdentity(def, parent, basePath, index, getRowId)
       const bucket = buckets.get(id)
       // Kind participates in matching (not just id): a kind mismatch must
       // not consume the candidate, so a later same-kind def can still match.
@@ -99,13 +132,24 @@ export function createMenuTreeResolver(): MenuTreeResolver {
 
     return defs.map((def, index) => {
       const node = matches[index]
-      const segment = segmentForDef(def)
-      const defPath = segment ? [...basePath, segment] : [...basePath]
-      const id = def.id ?? defPath.join('.')
+      const { segment, defPath, id } = prospectiveIdentity(
+        def,
+        parent,
+        basePath,
+        index,
+        getRowId,
+      )
 
       if (!node) {
-        const created = resolveNodeDefs([def], parent, basePath)[0]!
+        const created = resolveNodeDefs([def], parent, basePath, getRowId)[0]!
         created.index = index
+        created.id = prospectiveIdentity(
+          def,
+          parent,
+          basePath,
+          index,
+          getRowId,
+        ).id
         register(created)
         return created
       }

--- a/packages/react/src/internal/popup-menu/resolve/types.ts
+++ b/packages/react/src/internal/popup-menu/resolve/types.ts
@@ -34,3 +34,26 @@ export interface PopupMenuNode {
   /** Sibling index in the def tree (position within `parent.children`). */
   index: number
 }
+
+/**
+ * A menu node before its row id is assigned — the argument to `GetRowIdFn`.
+ * Carries definitional facts only (`def`, `segment`, `defPath`, resolved
+ * `parent`, `depth`, def-tree sibling `index`). Contextual facts (search
+ * state, deep-search flags, display position) are deliberately absent:
+ * a context-dependent row id is inexpressible by construction.
+ */
+export type UnidentifiedMenuNode = Omit<PopupMenuNode, 'id'>
+
+/**
+ * Computes a node's row id from definitional facts. The id must be unique
+ * per menu root; it is the identity persistent state, registration, and
+ * highlight key off.
+ *
+ * Contract: the id may read the node's own facts (including its own sibling
+ * `index`) and may walk `parent` for lineage (as the default definition-path
+ * rule does), but it must not depend on an *ancestor's* sibling `index` —
+ * reconciliation invalidates ids by def identity and definition path, not by
+ * ancestor reordering, so ancestor-index-dependent ids would go stale. The
+ * seam must also not mutate its argument.
+ */
+export type GetRowIdFn = (node: UnidentifiedMenuNode) => string


### PR DESCRIPTION
## Summary

Routes all resolver node-id computation through a `getRowId` seam per ADR-0001: `node.id` is now *defined as* `getRowId(unidentified node)`, where `UnidentifiedMenuNode` carries definitional facts only — context-dependent ids are inexpressible by construction. The default seam (`def.id` verbatim, else `defPath.join('.')`) is byte-identical to the previous hard-coded rule; zero behavior change.

## Changes

- `resolve/types.ts` — `UnidentifiedMenuNode` (`Omit<PopupMenuNode, 'id'>`), `GetRowIdFn` with a documented contract (own facts + lineage via `parent` allowed; ancestor-index-dependent ids forbidden; no argument mutation).
- `resolve/resolve.ts` — `defaultGetRowId`; `resolveNodeDefs` gains a required `getRowId` parameter and builds nodes via a no-`id` probe (`getRowId` called before the spread).
- `resolve/resolver.ts` — `createMenuTreeResolver(options?: { getRowId? })`; a shared `prospectiveIdentity` helper feeds the seam identical probes in the match and map phases; the create path recomputes the created root's id at its **real** sibling index before registration (single-element `resolveNodeDefs` calls otherwise compute it at index 0).
- Tests: mechanical 4th-argument additions (zero assertion edits — pins default-seam parity) + new `getRowId seam` describe: custom seam shapes ids, matching agrees with the seam, definitional-facts capture (no `id` own-property at call time), index-dependent seam stability, default parity.

## Motivation

First slice of the identity-through-the-seam stack (builds on #438): Parent C's breaking swap exposes `getRowId` publicly in place of `getQualifiedRowId`/`rowIdStrategy`; this slice makes the resolver's identity fully seam-driven while keeping the public surface and every id byte-identical. #440 makes the pipeline read these ids; #441 relocates duplicate detection to this single guard site.

## Tests

5 new unit tests in the `getRowId seam` block (see Changes); all 922 react tests green; `bun run check` / `bun run type-check` clean.

Closes [UI-461](https://linear.app/bazzalabs/issue/UI-461/route-resolver-node-ids-through-a-getrowid-seam)
