### PR TITLE
feat(popup-menu): add public `getRowId` to menu roots and expose resolver types

### DIFF
--- a/.changeset/public-getrowid.md
+++ b/.changeset/public-getrowid.md
@@ -1,0 +1,9 @@
+---
+'@bazza-ui/react': minor
+---
+
+Add the `getRowId` prop to `DropdownMenu.Root`, `ContextMenu.Root`, and `CommandMenu.Root`. It receives the unidentified resolved node (definitional facts only); by default, explicit `id` is used verbatim, otherwise the definition path is used.
+
+Export the `PopupMenuNode`, `GetRowIdFn`, and `UnidentifiedMenuNode` types, and deprecate `getNavigableIds` in favor of resolver nodes or `getOrderedItemIds`.
+
+The new prop supersedes `getQualifiedRowId` and `rowIdStrategy`, which are removed by the accompanying identity swap in this same release.

--- a/packages/react/src/combobox/root/root.tsx
+++ b/packages/react/src/combobox/root/root.tsx
@@ -409,6 +409,7 @@ export function ComboboxRoot<
     handleOpenChange: baseHandleOpenChange,
     disabled: menuDisabled,
     setDisabled,
+    menuTreeResolver,
   } = usePopupMenuRoot({
     // Cast to generic type - component handles type safety via narrowed types
     onOpenChange:
@@ -763,6 +764,7 @@ export function ComboboxRoot<
       value={comboboxContextValue as ComboboxContextValue<unknown>}
     >
       <PopupMenuProviders
+        menuTreeResolver={menuTreeResolver}
         store={store}
         focusOwnerStore={focusOwnerStore}
         openChainStore={openChainStore}

--- a/packages/react/src/command-menu/index.ts
+++ b/packages/react/src/command-menu/index.ts
@@ -79,6 +79,7 @@ export type {
   DisplayRowNode,
   DisplaySeparatorNode,
   DisplaySubpageNode,
+  GetRowIdFn,
   GroupBehavior,
   GroupDef,
   GroupRenderContext,
@@ -90,6 +91,7 @@ export type {
   ItemRenderProps,
   LoaderComponentProps,
   NodeDef,
+  PopupMenuNode,
   PopupMenuRadioGroupValueProps as CommandMenuRadioGroupValueProps,
   QueryAsyncNodesConfig,
   QueryDependentLoaderConfig,
@@ -114,6 +116,7 @@ export type {
   SubpageDef,
   SubpageTriggerRenderParams,
   SubpageTriggerRenderProps,
+  UnidentifiedMenuNode,
 } from '../internal/popup-menu/index.js'
 
 export {

--- a/packages/react/src/command-menu/root/root.tsx
+++ b/packages/react/src/command-menu/root/root.tsx
@@ -4,6 +4,7 @@ import { Dialog } from '@base-ui/react/dialog'
 import * as React from 'react'
 import type { PopupMenuOpenChangeReason } from '../../internal/popup-menu/events.js'
 import {
+  type GetRowIdFn,
   PopupMenuProviders,
   type UsePopupMenuRootParams,
   usePopupMenuRoot,
@@ -20,6 +21,14 @@ export interface CommandMenuRootProps {
   hotkey?: string
   modal?: boolean
   disabled?: boolean
+  /**
+   * Computes canonical row ids for data-first content from the unidentified resolved node (definitional facts only).
+   * @default explicit `def.id` verbatim, else the joined definition path
+   * Read once when the menu root mounts — later changes have no effect.
+   * @example
+   * <CommandMenu.Root getRowId={(node) => node.def.id ?? node.defPath.join('.')} />
+   */
+  getRowId?: GetRowIdFn
 }
 
 /**
@@ -37,6 +46,7 @@ export function CommandMenuRoot(props: CommandMenuRoot.Props) {
     hotkey,
     modal = true,
     disabled,
+    getRowId,
   } = props
 
   const {
@@ -47,12 +57,14 @@ export function CommandMenuRoot(props: CommandMenuRoot.Props) {
     closeAll,
     handleOpenChange,
     disabled: menuDisabled,
+    menuTreeResolver,
   } = usePopupMenuRoot({
     onOpenChange:
       onOpenChange as unknown as UsePopupMenuRootParams['onOpenChange'],
     defaultOpen,
     disabled,
     closeOnOutsidePress: 'pointerdown',
+    getRowId,
   })
 
   store.useControlledProp('openProp', openProp)
@@ -99,6 +111,7 @@ export function CommandMenuRoot(props: CommandMenuRoot.Props) {
 
   return (
     <PopupMenuProviders
+      menuTreeResolver={menuTreeResolver}
       store={store}
       focusOwnerStore={focusOwnerStore}
       openChainStore={openChainStore}

--- a/packages/react/src/context-menu/index.ts
+++ b/packages/react/src/context-menu/index.ts
@@ -242,6 +242,7 @@ export type {
   DisplayRadioGroupNode,
   DisplayRowNode,
   DisplaySubpageNode,
+  GetRowIdFn,
   GroupBehavior,
   GroupDef,
   GroupLabelRenderParams,
@@ -253,6 +254,7 @@ export type {
   ItemRenderParams,
   ItemRenderProps,
   NodeDef,
+  PopupMenuNode,
   PopupMenuRadioGroupValueProps as ContextMenuRadioGroupValueProps,
   RadioGroupDef,
   RadioGroupLabelRenderParams,
@@ -272,6 +274,7 @@ export type {
   TreeItemDef,
   TreeItemRenderParams,
   TreeItemRenderProps,
+  UnidentifiedMenuNode,
 } from '../internal/popup-menu/index.js'
 
 export {

--- a/packages/react/src/context-menu/root/root.tsx
+++ b/packages/react/src/context-menu/root/root.tsx
@@ -15,6 +15,7 @@ import {
   usePopupMenuRoot,
   type VirtualAnchor,
 } from '../../internal/popup-menu/index.js'
+import type { GetRowIdFn } from '../../internal/popup-menu/resolve/types.js'
 import type {
   ContextMenuHighlightChangeEventDetails,
   ContextMenuOpenChangeEventDetails,
@@ -124,6 +125,15 @@ export interface ContextMenuRootProps {
   rowIdStrategy?: RowIdStrategy
 
   /**
+   * Computes canonical row ids for data-first content from the unidentified resolved node (definitional facts only).
+   * @default explicit `def.id` verbatim, else the joined definition path
+   * Read once when the menu root mounts — later changes have no effect.
+   * @example
+   * <ContextMenu.Root getRowId={(node) => node.def.id ?? node.defPath.join('.')} />
+   */
+  getRowId?: GetRowIdFn
+
+  /**
    * Debug visualization options for submenu interaction heuristics.
    */
   debug?: PopupMenuDebugOptions
@@ -203,6 +213,7 @@ export function ContextMenuRoot(props: ContextMenuRoot.Props) {
     actionsRef,
     getQualifiedRowId,
     rowIdStrategy,
+    getRowId,
     debug,
     children,
   } = props
@@ -218,6 +229,7 @@ export function ContextMenuRoot(props: ContextMenuRoot.Props) {
     handleOpenChange,
     disabled: menuDisabled,
     setDisabled,
+    menuTreeResolver,
   } = usePopupMenuRoot({
     // Cast to generic type - component handles type safety via narrowed types
     onOpenChange:
@@ -229,6 +241,7 @@ export function ContextMenuRoot(props: ContextMenuRoot.Props) {
       onHighlightChange as unknown as UsePopupMenuRootParams['onHighlightChange'],
     closeOnOutsidePress,
     disabled: disabledProp,
+    getRowId,
   })
 
   const popoverActionsRef = React.useRef<Popover.Root.Actions | null>(null)
@@ -325,6 +338,7 @@ export function ContextMenuRoot(props: ContextMenuRoot.Props) {
   return (
     <ContextMenuInternalContext.Provider value={internalContextValue}>
       <PopupMenuProviders
+        menuTreeResolver={menuTreeResolver}
         store={store}
         focusOwnerStore={focusOwnerStore}
         openChainStore={openChainStore}

--- a/packages/react/src/dropdown-menu/index.ts
+++ b/packages/react/src/dropdown-menu/index.ts
@@ -259,6 +259,7 @@ export type {
   DisplayRowNode,
   DisplaySeparatorNode,
   DisplaySubpageNode,
+  GetRowIdFn,
   GroupBehavior,
   GroupDef,
   GroupLabelRenderParams,
@@ -271,6 +272,7 @@ export type {
   ItemRenderProps,
   LoaderComponentProps,
   NodeDef,
+  PopupMenuNode,
   PopupMenuRadioGroupValueProps as DropdownMenuRadioGroupValueProps,
   QueryAsyncNodesConfig,
   QueryDependentLoaderConfig,
@@ -299,6 +301,7 @@ export type {
   TreeItemDef,
   TreeItemRenderParams,
   TreeItemRenderProps,
+  UnidentifiedMenuNode,
 } from '../internal/popup-menu/index.js'
 
 export {

--- a/packages/react/src/dropdown-menu/root/root.tsx
+++ b/packages/react/src/dropdown-menu/root/root.tsx
@@ -14,6 +14,7 @@ import {
   type UsePopupMenuRootParams,
   usePopupMenuRoot,
 } from '../../internal/popup-menu/index.js'
+import type { GetRowIdFn } from '../../internal/popup-menu/resolve/types.js'
 import type {
   DropdownMenuHighlightChangeEventDetails,
   DropdownMenuOpenChangeEventDetails,
@@ -142,6 +143,15 @@ export interface DropdownMenuRootProps
   rowIdStrategy?: RowIdStrategy
 
   /**
+   * Computes canonical row ids for data-first content from the unidentified resolved node (definitional facts only).
+   * @default explicit `def.id` verbatim, else the joined definition path
+   * Read once when the menu root mounts — later changes have no effect.
+   * @example
+   * <DropdownMenu.Root getRowId={(node) => node.def.id ?? node.defPath.join('.')} />
+   */
+  getRowId?: GetRowIdFn
+
+  /**
    * Debug visualization options for submenu interaction heuristics.
    */
   debug?: PopupMenuDebugOptions
@@ -169,6 +179,7 @@ export function DropdownMenuRoot(props: DropdownMenuRoot.Props) {
     actionsRef,
     getQualifiedRowId,
     rowIdStrategy,
+    getRowId,
     debug,
     children,
     ...rest
@@ -185,6 +196,7 @@ export function DropdownMenuRoot(props: DropdownMenuRoot.Props) {
     handleOpenChange,
     disabled: menuDisabled,
     setDisabled,
+    menuTreeResolver,
   } = usePopupMenuRoot({
     // Cast to generic type - component handles type safety via narrowed types
     onOpenChange:
@@ -196,6 +208,7 @@ export function DropdownMenuRoot(props: DropdownMenuRoot.Props) {
       onHighlightChange as unknown as UsePopupMenuRootParams['onHighlightChange'],
     closeOnOutsidePress,
     disabled,
+    getRowId,
   })
 
   const popoverActionsRef = useRef<Popover.Root.Actions | null>(null)
@@ -256,6 +269,7 @@ export function DropdownMenuRoot(props: DropdownMenuRoot.Props) {
   return (
     <PopupMenuProviders
       store={store}
+      menuTreeResolver={menuTreeResolver}
       focusOwnerStore={focusOwnerStore}
       openChainStore={openChainStore}
       disabled={menuDisabled}

--- a/packages/react/src/internal/popup-menu/components/providers.tsx
+++ b/packages/react/src/internal/popup-menu/components/providers.tsx
@@ -29,7 +29,7 @@ import type {
   RowIdStrategy,
 } from '../deep-search/types.js'
 import { AimGuardProvider } from '../hooks/use-aim-guard.js'
-import { createMenuTreeResolver } from '../resolve/resolver.js'
+import type { MenuTreeResolver } from '../resolve/resolver.js'
 import type { FocusOwnerStore } from '../store/FocusOwnerStore.js'
 import { FocusZoneRegistry } from '../store/FocusZoneRegistry.js'
 import type { OpenChainStore } from '../store/OpenChainStore.js'
@@ -39,6 +39,8 @@ import type { OpenChainStore } from '../store/OpenChainStore.js'
 // ============================================================================
 
 export interface PopupMenuProvidersProps {
+  /** Created by `usePopupMenuRoot`, one per menu root. */
+  menuTreeResolver: MenuTreeResolver
   /** The Listbox store instance */
   store: ListboxStore
   /** The FocusOwner store instance */
@@ -136,18 +138,12 @@ export function PopupMenuProviders(props: PopupMenuProvidersProps) {
     rowIdStrategy,
     componentName,
     children,
+    menuTreeResolver,
   } = props
 
   const focusZoneRegistryRef = React.useRef<FocusZoneRegistry | null>(null)
   if (!focusZoneRegistryRef.current) {
     focusZoneRegistryRef.current = new FocusZoneRegistry()
-  }
-
-  const menuTreeResolverRef = React.useRef<ReturnType<
-    typeof createMenuTreeResolver
-  > | null>(null)
-  if (menuTreeResolverRef.current === null) {
-    menuTreeResolverRef.current = createMenuTreeResolver()
   }
 
   // PopupMenu context value
@@ -212,7 +208,7 @@ export function PopupMenuProviders(props: PopupMenuProvidersProps) {
   )
 
   return (
-    <MenuTreeResolverContext.Provider value={menuTreeResolverRef.current}>
+    <MenuTreeResolverContext.Provider value={menuTreeResolver}>
       <ComponentNameContext.Provider value={componentName}>
         <PopupMenuDebugContext.Provider value={popupMenuDebugContextValue}>
           <PopupMenuContext.Provider value={popupMenuContextValue}>

--- a/packages/react/src/internal/popup-menu/deep-search/utils.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/utils.ts
@@ -1611,6 +1611,8 @@ export function filterNodes(options: FilterNodesOptions): {
  *
  * Note: Uses `node.id ?? node.value` as the identifier. For proper ID handling
  * with custom getItemId functions, use `getOrderedItemIds` from DataList instead.
+ *
+ * @deprecated Deprecated: reads `node.id ?? node.value` from defs and ignores the resolver's canonical row ids. Use `getOrderedItemIds` (DataList) or resolved menu nodes instead. Will be removed in a future release.
  */
 export function getNavigableIds(displayNodes: DisplayNode[]): string[] {
   const ids: string[] = []

--- a/packages/react/src/internal/popup-menu/hooks/use-popup-menu-root.ts
+++ b/packages/react/src/internal/popup-menu/hooks/use-popup-menu-root.ts
@@ -13,6 +13,9 @@ import { ensureInputModalityTracking } from '../../../utils/input-modality.js'
 import { ListboxStore, type VirtualItem } from '../../listbox/index.js'
 import type { VirtualizationConfig } from '../contexts/popup-menu-context.js'
 import type { PopupMenuOpenChangeReason } from '../events.js'
+import type { MenuTreeResolver } from '../resolve/resolver.js'
+import { createMenuTreeResolver } from '../resolve/resolver.js'
+import type { GetRowIdFn } from '../resolve/types.js'
 import { FocusOwnerStore } from '../store/FocusOwnerStore.js'
 import { OpenChainStore } from '../store/OpenChainStore.js'
 
@@ -21,6 +24,12 @@ import { OpenChainStore } from '../store/OpenChainStore.js'
 // ============================================================================
 
 export interface UsePopupMenuRootParams {
+  /**
+   * Computes canonical row ids for data-first content from the unidentified resolved node (definitional facts only).
+   * @default explicit `def.id` verbatim, else the joined definition path
+   * Read once when the menu root mounts — later changes have no effect.
+   */
+  getRowId?: GetRowIdFn
   /**
    * Callback when the open state changes.
    * The second parameter contains event details including the reason for the change.
@@ -90,6 +99,8 @@ export interface PopupMenuRootActions {
 }
 
 export interface UsePopupMenuRootReturn {
+  /** The menu-tree resolver for this menu root. */
+  menuTreeResolver: MenuTreeResolver
   /** The Listbox store instance */
   store: ListboxStore
   /** The FocusOwner store instance */
@@ -143,7 +154,16 @@ export function usePopupMenuRoot(
     closeOnOutsidePress = 'pointerdown',
     disabled: disabledProp = false,
     defaultDisabled = false,
+    getRowId,
   } = params
+
+  const menuTreeResolverRef = React.useRef<MenuTreeResolver | null>(null)
+  if (menuTreeResolverRef.current === null) {
+    menuTreeResolverRef.current = createMenuTreeResolver(
+      getRowId ? { getRowId } : undefined,
+    )
+  }
+  const menuTreeResolver = menuTreeResolverRef.current
 
   const [imperativeDisabled, setImperativeDisabled] =
     React.useState(defaultDisabled)
@@ -346,6 +366,7 @@ export function usePopupMenuRoot(
   }, [virtualized, itemsProp, onHighlightChange])
 
   return {
+    menuTreeResolver,
     store,
     focusOwnerStore,
     openChainStore,

--- a/packages/react/src/internal/popup-menu/index.ts
+++ b/packages/react/src/internal/popup-menu/index.ts
@@ -529,3 +529,10 @@ export {
   shouldLoadEagerly,
   sortByScore,
 } from './deep-search/utils.js'
+export { defaultGetRowId } from './resolve/resolve.js'
+export type { MenuTreeResolver } from './resolve/resolver.js'
+export type {
+  GetRowIdFn,
+  PopupMenuNode,
+  UnidentifiedMenuNode,
+} from './resolve/types.js'

--- a/packages/react/src/internal/popup-menu/resolve/__tests__/mount.test.tsx
+++ b/packages/react/src/internal/popup-menu/resolve/__tests__/mount.test.tsx
@@ -5,6 +5,7 @@ import { DropdownMenu } from '../../../../dropdown-menu/index.js'
 import { useMenuTreeResolver } from '../../contexts/menu-tree-resolver-context.js'
 import type { ItemDef, NodeDef, SubmenuDef } from '../../deep-search/types.js'
 import type { MenuTreeResolver } from '../resolver.js'
+import type { GetRowIdFn } from '../types.js'
 
 function item(value: string): ItemDef {
   return {
@@ -35,13 +36,15 @@ function Menu({
   content,
   onResolver,
   search = false,
+  getRowId,
 }: {
   content: NodeDef[]
   onResolver: (value: MenuTreeResolver) => void
   search?: boolean
+  getRowId?: GetRowIdFn
 }) {
   return (
-    <DropdownMenu.Root defaultOpen>
+    <DropdownMenu.Root defaultOpen getRowId={getRowId}>
       <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
       <Probe onResolver={onResolver} />
       <DropdownMenu.Portal>
@@ -100,6 +103,28 @@ function submenu(
 }
 
 describe('mounted menu-tree resolution', () => {
+  describe('public getRowId prop', () => {
+    it('uses the custom row-id seam for resolver node ids', async () => {
+      let resolver!: MenuTreeResolver
+      render(
+        <Menu
+          onResolver={(value) => {
+            resolver = value
+          }}
+          getRowId={(node) => `x-${node.def.id ?? node.segment}`}
+          content={[item('Settings'), submenu('Status', [item('Backlog')], [])]}
+        />,
+      )
+
+      await waitFor(() =>
+        expect(resolver.getNodeById('x-status')).toBeDefined(),
+      )
+      expect(resolver.getNodeById('x-status')?.children[0]?.id).toBe(
+        'x-backlog',
+      )
+    })
+  })
+
   it('resolves root content with qualified definition paths', async () => {
     let resolver!: MenuTreeResolver
     render(

--- a/packages/react/src/internal/popup-menu/resolve/resolver.ts
+++ b/packages/react/src/internal/popup-menu/resolve/resolver.ts
@@ -39,6 +39,8 @@ const ROW_KINDS: ReadonlySet<NodeDef['kind']> = new Set<RowKind>([
  * identical arguments are no-ops.
  */
 export interface MenuTreeResolver {
+  /** The row-id seam this resolver was created with. */
+  readonly getRowId: GetRowIdFn
   /** Current root nodes, in def order. */
   readonly rootNodes: readonly PopupMenuNode[]
   /** Re-supply the root def list and reconcile the whole tree. */
@@ -218,6 +220,7 @@ export function createMenuTreeResolver(
   }
 
   return {
+    getRowId,
     get rootNodes() {
       return rootNodes
     },

--- a/packages/react/src/select/root/root.tsx
+++ b/packages/react/src/select/root/root.tsx
@@ -355,6 +355,7 @@ export function SelectRoot<
     handleOpenChange,
     disabled: menuDisabled,
     setDisabled,
+    menuTreeResolver,
   } = usePopupMenuRoot({
     // Cast to generic type - component handles type safety via narrowed types
     onOpenChange:
@@ -580,6 +581,7 @@ export function SelectRoot<
       value={selectContextValue as SelectContextValue<unknown>}
     >
       <PopupMenuProviders
+        menuTreeResolver={menuTreeResolver}
         store={store}
         focusOwnerStore={focusOwnerStore}
         openChainStore={openChainStore}


### PR DESCRIPTION
## Summary

Adds the public `getRowId` prop — the consumer-facing row-identity seam from ADR-0001 — to `DropdownMenu.Root`, `ContextMenu.Root`, and `CommandMenu.Root`, routed into the root-owned menu-tree resolver. Purely additive.

## Changes

- `resolve/resolver.ts`: `MenuTreeResolver` exposes `readonly getRowId` (the effective seam after defaulting).
- `hooks/use-popup-menu-root.ts`: resolver creation relocates here from `PopupMenuProviders` (lazy ref, mount-static), with a new optional `getRowId` param; the hook returns `menuTreeResolver`.
- `components/providers.tsx`: takes a required `menuTreeResolver` prop and provides it via `MenuTreeResolverContext`; no longer creates the resolver.
- All five callers (`dropdown-menu`, `context-menu`, `command-menu`, `select`, `combobox` roots) thread the resolver; the three data-first families additionally expose the public `getRowId?: GetRowIdFn` prop (JSDoc + example). Select/Combobox get no public prop.
- Exports: `PopupMenuNode`, `UnidentifiedMenuNode`, `GetRowIdFn`, `MenuTreeResolver`, and `defaultGetRowId` from the internal barrel; `GetRowIdFn`/`UnidentifiedMenuNode`/`PopupMenuNode` from the three family barrels.
- `getNavigableIds` gains an `@deprecated` JSDoc (deprecate-don't-delete, per the parent plan).
- Changeset `.changeset/public-getrowid.md` (`minor`).

## Motivation

This is slice 1 of the Parent C breaking swap ([UI-459](https://linear.app/bazzalabs/issue/UI-459/breaking-swap-render-params-and-events-carry-menu-nodes-parent-c)): the additive seam lands before the destructive swap so the next PR can delete `getQualifiedRowId`/`rowIdStrategy` while custom row ids already have their replacement. Moving resolver creation into `usePopupMenuRoot` also positions the root hook to wrap `onHighlightChange` with a node lookup two slices later. Builds on #440; #442 (identity swap) depends on this landing first.

`getRowId` is mount-static by design: the resolver is created once per menu root, so the prop is read at mount and later changes have no effect (documented in the JSDoc).

## Tests

- New: `mount.test.tsx` › `public getRowId prop` › `uses the custom row-id seam for resolver node ids` — mounts `DropdownMenu.Root` with a custom seam and asserts prefixed resolver node ids for a submenu and its child.
- Full gates: `bun run check`, `bun run type-check`, `bun run test --filter @bazza-ui/react` (928 tests) all pass.

Closes [UI-464](https://linear.app/bazzalabs/issue/UI-464/add-public-getrowid-to-menu-roots)
