### PR TITLE
feat(popup-menu)!: `onHighlightChange` carries the resolved node

### DIFF
--- a/.changeset/highlight-carries-node.md
+++ b/.changeset/highlight-carries-node.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': minor
+---
+
+**Breaking change.** `onHighlightChange` on `DropdownMenu.Root`, `ContextMenu.Root`, and `Submenu` is now `(id, node, index, eventDetails)` — `id` remains first for both JSX and data-first rows, while `node` is second as nullable enrichment. `node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree (`null` when the highlight clears or when no data-first node carries that id — e.g. JSX-defined rows; a JSX row that deliberately shares an id with a data-first node yields that node). `Select`/`Combobox` signatures are unchanged. Migration: `(id, index) => …` → `(id, node, index) => …`.

--- a/apps/web/registry/examples/components/dropdown-menu/deep-search-subpages-linear/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/deep-search-subpages-linear/index.tsx
@@ -192,7 +192,7 @@ function createLabelsSubmenu(params: {
   labelCreationStatus: LabelCreationStatus
   creatingLabelName: string | null
   creatingLabelColor: string
-  onHighlightChange: (id: string | null, index: number) => void
+  onHighlightChange: (id: string | null, _node: unknown, index: number) => void
 }): SubmenuDef {
   const {
     labels,
@@ -413,7 +413,11 @@ function buildMenuContent(params: {
   labelCreationStatus: LabelCreationStatus
   creatingLabelName: string | null
   creatingLabelColor: string
-  onLabelHighlightChange: (id: string | null, index: number) => void
+  onLabelHighlightChange: (
+    id: string | null,
+    _node: unknown,
+    index: number,
+  ) => void
 }): NodeDef[] {
   const {
     labels,
@@ -746,7 +750,7 @@ export default function DropdownMenuDeepSearchSubpagesLinear() {
   )
 
   const handleLabelHighlightChange = React.useCallback(
-    (id: string | null, _index: number) => {
+    (id: string | null, _node: unknown, _index: number) => {
       if (!id) return
       // Color items have values like "labelName:colorId"
       const colonIndex = id.lastIndexOf(':')

--- a/apps/web/registry/examples/components/dropdown-menu/linear-subpage-label-creation/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/linear-subpage-label-creation/index.tsx
@@ -353,21 +353,24 @@ export default function DropdownMenuLinearSubpageLabelCreation() {
     [],
   )
 
-  const handleLabelHighlightChange = React.useCallback((id: string | null) => {
-    if (!id) {
-      return
-    }
+  const handleLabelHighlightChange = React.useCallback(
+    (id: string | null, _node: unknown) => {
+      if (!id) {
+        return
+      }
 
-    const colonIndex = id.lastIndexOf(':')
-    if (colonIndex === -1) {
-      return
-    }
+      const colonIndex = id.lastIndexOf(':')
+      if (colonIndex === -1) {
+        return
+      }
 
-    const colorId = id.slice(colonIndex + 1)
-    if (CREATABLE_LABEL_COLORS.some((c) => c.id === colorId)) {
-      setCreatingLabelColor(colorId)
-    }
-  }, [])
+      const colorId = id.slice(colonIndex + 1)
+      if (CREATABLE_LABEL_COLORS.some((c) => c.id === colorId)) {
+        setCreatingLabelColor(colorId)
+      }
+    },
+    [],
+  )
 
   React.useEffect(() => {
     if (!pendingCreatedLabelId) {

--- a/apps/web/registry/examples/components/dropdown-menu/virtualized-advanced/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/virtualized-advanced/index.tsx
@@ -350,7 +350,7 @@ export default function DropdownMenuVirtualizedAdvanced() {
 
   // Sync virtualizer scroll with keyboard highlight
   const handleHighlightChange = React.useCallback(
-    (_id: string | null, index: number) => {
+    (_id: string | null, _node: unknown, index: number) => {
       if (index < 0) return
 
       // Map selectable item index to row index

--- a/apps/web/registry/examples/components/dropdown-menu/virtualized-submenus/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/virtualized-submenus/index.tsx
@@ -160,7 +160,7 @@ function VirtualizedMenuContent({
   )
 
   const handleHighlightChange = React.useCallback(
-    (_id: string | null, index: number) => {
+    (_id: string | null, _node: unknown, index: number) => {
       if (index >= 0) {
         queueMicrotask(() => {
           virtualizer.scrollToIndex(index, { align: 'auto' })
@@ -331,7 +331,7 @@ function VirtualizedSubmenu({ item, depth }: VirtualizedSubmenuProps) {
   )
 
   const handleHighlightChange = React.useCallback(
-    (_id: string | null, index: number) => {
+    (_id: string | null, _node: unknown, index: number) => {
       if (index >= 0) {
         queueMicrotask(() => {
           virtualizer.scrollToIndex(index, { align: 'auto' })

--- a/apps/web/registry/examples/components/dropdown-menu/virtualized/index.tsx
+++ b/apps/web/registry/examples/components/dropdown-menu/virtualized/index.tsx
@@ -68,6 +68,7 @@ export default function DropdownMenuVirtualized() {
   const handleHighlightChange = React.useCallback(
     (
       id: string | null,
+      _node: unknown,
       index: number,
       details: DropdownMenuRoot.HighlightChangeEventDetails,
     ) => {

--- a/packages/react/src/combobox/root/root.tsx
+++ b/packages/react/src/combobox/root/root.tsx
@@ -6,6 +6,7 @@ import type { VirtualItem } from '../../internal/listbox/index.js'
 import type { PopupMenuOpenChangeReason } from '../../internal/popup-menu/events.js'
 import {
   type PopupMenuDebugOptions,
+  type PopupMenuHighlightChangeHandler,
   PopupMenuProviders,
   type PopupMenuRootActions,
   type UsePopupMenuRootParams,
@@ -362,6 +363,17 @@ export function ComboboxRoot<
     ...rest
   } = props
 
+  const handleHighlightChange =
+    React.useCallback<PopupMenuHighlightChangeHandler>(
+      (id, _node, index, details) =>
+        onHighlightChange?.(
+          id,
+          index,
+          details as ComboboxHighlightChangeEventDetails,
+        ),
+      [onHighlightChange],
+    )
+
   // Generate a unique ID for the listbox
   const listId = React.useId()
 
@@ -417,8 +429,7 @@ export function ComboboxRoot<
     defaultOpen,
     virtualized,
     items: virtualItems,
-    onHighlightChange:
-      onHighlightChange as unknown as UsePopupMenuRootParams['onHighlightChange'],
+    onHighlightChange: handleHighlightChange,
     disabled: disabledProp,
   })
 

--- a/packages/react/src/context-menu/root/root.tsx
+++ b/packages/react/src/context-menu/root/root.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import type { VirtualItem } from '../../internal/listbox/index.js'
 import {
   type PopupMenuDebugOptions,
+  type PopupMenuHighlightChangeHandler,
   PopupMenuProviders,
   type PopupMenuRootActions,
   type UsePopupMenuRootParams,
@@ -58,13 +59,10 @@ export interface ContextMenuRootProps {
   /**
    * Callback when the highlighted item changes.
    * Useful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.
-   * The third parameter contains event details including the reason for the change.
+   * `id` is first. `node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.
+   * The fourth parameter contains event details including the reason for the change.
    */
-  onHighlightChange?: (
-    id: string | null,
-    index: number,
-    eventDetails: ContextMenuHighlightChangeEventDetails,
-  ) => void
+  onHighlightChange?: PopupMenuHighlightChangeHandler<ContextMenuHighlightChangeEventDetails>
 
   /**
    * Whether the component should ignore user interaction.

--- a/packages/react/src/dropdown-menu/root/root.test.tsx
+++ b/packages/react/src/dropdown-menu/root/root.test.tsx
@@ -2549,6 +2549,7 @@ describe('<DropdownMenu.Root />', () => {
       await waitFor(() => {
         expect(onRootHighlightChange).toHaveBeenCalledWith(
           'highlight-root-item',
+          null,
           0,
           expect.objectContaining({ reason: expect.any(String) }),
         )
@@ -2586,6 +2587,7 @@ describe('<DropdownMenu.Root />', () => {
       await waitFor(() => {
         expect(onRootHighlightChange).toHaveBeenCalledWith(
           'highlight-root-subpage-item',
+          null,
           expect.any(Number),
           expect.objectContaining({ reason: 'keyboard' }),
         )
@@ -2628,6 +2630,7 @@ describe('<DropdownMenu.Root />', () => {
       await waitFor(() => {
         expect(onSubmenuHighlightChange).toHaveBeenCalledWith(
           'highlight-submenu-item',
+          null,
           expect.any(Number),
           expect.objectContaining({ reason: expect.any(String) }),
         )
@@ -2677,6 +2680,7 @@ describe('<DropdownMenu.Root />', () => {
       await waitFor(() => {
         expect(onSubmenuHighlightChange).toHaveBeenCalledWith(
           'highlight-submenu-subpage-item',
+          null,
           expect.any(Number),
           expect.objectContaining({ reason: expect.any(String) }),
         )

--- a/packages/react/src/dropdown-menu/root/root.tsx
+++ b/packages/react/src/dropdown-menu/root/root.tsx
@@ -5,6 +5,7 @@ import { useCallback, useImperativeHandle, useRef } from 'react'
 import type { VirtualItem } from '../../internal/listbox/index.js'
 import {
   type PopupMenuDebugOptions,
+  type PopupMenuHighlightChangeHandler,
   PopupMenuProviders,
   type PopupMenuRootActions,
   type UsePopupMenuRootParams,
@@ -80,13 +81,10 @@ export interface DropdownMenuRootProps
   /**
    * Callback when the highlighted item changes.
    * Useful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.
-   * The third parameter contains event details including the reason for the change.
+   * `id` is first. `node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.
+   * The fourth parameter contains event details including the reason for the change.
    */
-  onHighlightChange?: (
-    id: string | null,
-    index: number,
-    eventDetails: DropdownMenuHighlightChangeEventDetails,
-  ) => void
+  onHighlightChange?: PopupMenuHighlightChangeHandler<DropdownMenuHighlightChangeEventDetails>
 
   /**
    * When to close the menu on outside interactions (clicking outside or clicking the trigger when open).

--- a/packages/react/src/internal/popup-menu/components/submenu-root/submenu-root.tsx
+++ b/packages/react/src/internal/popup-menu/components/submenu-root/submenu-root.tsx
@@ -9,12 +9,17 @@ import {
   useSurfaceContext,
   type VirtualItem,
 } from '../../../listbox/index.js'
+import { useMenuTreeResolver } from '../../contexts/menu-tree-resolver-context.js'
 import { useOpenChain } from '../../contexts/open-chain-context.js'
 import {
   PopupMenuContext,
   useMaybePopupMenuContext,
 } from '../../contexts/popup-menu-context.js'
 import { SubmenuContext } from '../../contexts/submenu-context.js'
+import type {
+  HighlightChangeEventDetails,
+  PopupMenuHighlightChangeHandler,
+} from '../../events.js'
 import type { PopupMenuRootActions } from '../../hooks/use-popup-menu-root.js'
 
 export interface PopupMenuSubmenuRootProps
@@ -68,10 +73,11 @@ export interface PopupMenuSubmenuRootProps
   items?: VirtualItem[]
 
   /**
-   * Callback when the highlighted item changes.
+   * Callback when the highlighted item changes. `id` is first; `node` is the
+   * resolved menu node enrichment and may be null.
    * Useful for synchronizing with a virtualizer (e.g., scrollToIndex).
    */
-  onHighlightChange?: (id: string | null, index: number) => void
+  onHighlightChange?: PopupMenuHighlightChangeHandler<HighlightChangeEventDetails>
 
   /**
    * Event handler called after any open/close animations have completed.
@@ -125,6 +131,23 @@ export function PopupMenuSubmenuRoot(props: PopupMenuSubmenuRootProps) {
   const parentDepth = parentListboxContext?.depth ?? 0
   const parentCloseAll = parentListboxContext?.closeAll
   const parentRegisterSurface = parentListboxContext?.registerSurface
+  const menuTreeResolver = useMenuTreeResolver()
+
+  const handleHighlightChange = React.useCallback(
+    (
+      id: string | null,
+      index: number,
+      eventDetails: HighlightChangeEventDetails,
+    ) => {
+      onHighlightChange?.(
+        id,
+        id === null ? null : (menuTreeResolver?.getNodeById(id) ?? null),
+        index,
+        eventDetails,
+      )
+    },
+    [menuTreeResolver, onHighlightChange],
+  )
 
   // Get parent surface ID for keyboard navigation back
   const { surfaceId: parentSurfaceId } = useSurfaceContext()
@@ -296,9 +319,9 @@ export function PopupMenuSubmenuRoot(props: PopupMenuSubmenuRootProps) {
     return {
       virtualized,
       items: itemsProp ?? [],
-      onHighlightChange,
+      onHighlightChange: handleHighlightChange,
     }
-  }, [virtualized, itemsProp, onHighlightChange])
+  }, [virtualized, itemsProp, handleHighlightChange, onHighlightChange])
 
   // Listbox context value with incremented depth
   // Pass parent's closeAll and registerSurface through unchanged

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
@@ -311,6 +311,62 @@ function MenuWithForcedSorting() {
 // ============================================================================
 
 describe('useDataList', () => {
+  it('passes the resolved node for data-first highlights', async () => {
+    const user = userEvent.setup()
+    const onHighlightChange = vi.fn()
+    const row: ItemDef = {
+      kind: 'item',
+      id: 'data-first-row',
+      value: 'Data first row',
+      render: ({ props }) => (
+        <DropdownMenu.Item {...props}>Row</DropdownMenu.Item>
+      ),
+    }
+    const secondRow: ItemDef = {
+      kind: 'item',
+      id: 'data-first-second-row',
+      value: 'Data first second row',
+      render: ({ props }) => (
+        <DropdownMenu.Item {...props}>Second row</DropdownMenu.Item>
+      ),
+    }
+
+    render(
+      <DropdownMenu.Root defaultOpen onHighlightChange={onHighlightChange}>
+        <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Positioner>
+            <DropdownMenu.Popup>
+              <DropdownMenu.Surface content={[secondRow, row]}>
+                <DropdownMenu.List data-testid="data-first-highlight-list">
+                  <ListItems />
+                </DropdownMenu.List>
+              </DropdownMenu.Surface>
+            </DropdownMenu.Popup>
+          </DropdownMenu.Positioner>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>,
+    )
+
+    await screen.findByText('Row')
+    screen.getByTestId('data-first-highlight-list').focus()
+    // Auto-highlight may claim the first row before the callback registers;
+    // moving to the second row guarantees a highlight *change* is observed.
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard('{ArrowDown}')
+
+    await waitFor(() => {
+      expect(onHighlightChange).toHaveBeenCalled()
+      const call = onHighlightChange.mock.calls
+        .filter((entry) => entry[0] === 'data-first-row')
+        .at(-1)
+      expect(call).toBeDefined()
+      expect(call?.[1]).not.toBeNull()
+      expect(call?.[1].id).toBe('data-first-row')
+      expect(call?.[1].def).toBe(row)
+    })
+  })
+
   it('warns for duplicate id-less values in one surface', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     render(

--- a/packages/react/src/internal/popup-menu/events.ts
+++ b/packages/react/src/internal/popup-menu/events.ts
@@ -3,6 +3,7 @@ import type {
   GenericEventDetails,
   REASONS,
 } from '../../utils/events/index.js'
+import type { PopupMenuNode } from './resolve/types.js'
 
 // ============================================================================
 // Shared Popup Menu Event Types
@@ -50,6 +51,15 @@ export type HighlightChangeEventDetails = GenericEventDetails<
   HighlightChangeReason,
   { index: number }
 >
+
+export type PopupMenuHighlightChangeHandler<
+  EventDetails = HighlightChangeEventDetails,
+> = (
+  id: string | null,
+  node: PopupMenuNode | null,
+  index: number,
+  eventDetails: EventDetails,
+) => void
 
 /**
  * Reasons why an item was selected.

--- a/packages/react/src/internal/popup-menu/hooks/use-popup-menu-root.ts
+++ b/packages/react/src/internal/popup-menu/hooks/use-popup-menu-root.ts
@@ -1,10 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import type {
-  ChangeEventDetails,
-  GenericEventDetails,
-} from '../../../utils/events/index.js'
+import type { ChangeEventDetails } from '../../../utils/events/index.js'
 import {
   createChangeEventDetails,
   REASONS,
@@ -12,7 +9,11 @@ import {
 import { ensureInputModalityTracking } from '../../../utils/input-modality.js'
 import { ListboxStore, type VirtualItem } from '../../listbox/index.js'
 import type { VirtualizationConfig } from '../contexts/popup-menu-context.js'
-import type { PopupMenuOpenChangeReason } from '../events.js'
+import type {
+  HighlightChangeEventDetails,
+  PopupMenuHighlightChangeHandler,
+  PopupMenuOpenChangeReason,
+} from '../events.js'
 import type { MenuTreeResolver } from '../resolve/resolver.js'
 import { createMenuTreeResolver } from '../resolve/resolver.js'
 import type { GetRowIdFn } from '../resolve/types.js'
@@ -57,14 +58,11 @@ export interface UsePopupMenuRootParams {
   items?: VirtualItem[]
 
   /**
-   * Callback when the highlighted item changes.
-   * The third parameter contains event details including the reason for the change.
+   * Callback when the highlighted item changes. `id` is first; `node` is the
+   * resolved menu node enrichment and may be null.
+   * The fourth parameter contains event details including the reason for the change.
    */
-  onHighlightChange?: (
-    id: string | null,
-    index: number,
-    eventDetails: GenericEventDetails<string, { index: number }>,
-  ) => void
+  onHighlightChange?: PopupMenuHighlightChangeHandler<HighlightChangeEventDetails>
 
   /**
    * When to close the menu on outside interactions.
@@ -164,6 +162,22 @@ export function usePopupMenuRoot(
     )
   }
   const menuTreeResolver = menuTreeResolverRef.current
+
+  const handleHighlightChange = React.useCallback(
+    (
+      id: string | null,
+      index: number,
+      eventDetails: HighlightChangeEventDetails,
+    ) => {
+      onHighlightChange?.(
+        id,
+        id === null ? null : (menuTreeResolver.getNodeById(id) ?? null),
+        index,
+        eventDetails,
+      )
+    },
+    [menuTreeResolver, onHighlightChange],
+  )
 
   const [imperativeDisabled, setImperativeDisabled] =
     React.useState(defaultDisabled)
@@ -361,9 +375,9 @@ export function usePopupMenuRoot(
     return {
       virtualized,
       items: itemsProp ?? [],
-      onHighlightChange,
+      onHighlightChange: handleHighlightChange,
     }
-  }, [virtualized, itemsProp, onHighlightChange])
+  }, [virtualized, itemsProp, handleHighlightChange, onHighlightChange])
 
   return {
     menuTreeResolver,

--- a/packages/react/src/internal/popup-menu/index.ts
+++ b/packages/react/src/internal/popup-menu/index.ts
@@ -524,6 +524,7 @@ export {
   shouldLoadEagerly,
   sortByScore,
 } from './deep-search/utils.js'
+export type { PopupMenuHighlightChangeHandler } from './events.js'
 export { defaultGetRowId, isPopupMenuNode } from './resolve/resolve.js'
 export type { MenuTreeResolver } from './resolve/resolver.js'
 export type {

--- a/packages/react/src/select/root/root.tsx
+++ b/packages/react/src/select/root/root.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import type { VirtualItem } from '../../internal/listbox/index.js'
 import {
   type PopupMenuDebugOptions,
+  type PopupMenuHighlightChangeHandler,
   PopupMenuProviders,
   type PopupMenuRootActions,
   type UsePopupMenuRootParams,
@@ -311,6 +312,17 @@ export function SelectRoot<
     ...rest
   } = props
 
+  const handleHighlightChange =
+    React.useCallback<PopupMenuHighlightChangeHandler>(
+      (id, _node, index, details) =>
+        onHighlightChange?.(
+          id,
+          index,
+          details as SelectHighlightChangeEventDetails,
+        ),
+      [onHighlightChange],
+    )
+
   // Generate a unique ID for the listbox
   const listId = React.useId()
 
@@ -363,8 +375,7 @@ export function SelectRoot<
     defaultOpen,
     virtualized,
     items: virtualItems,
-    onHighlightChange:
-      onHighlightChange as unknown as UsePopupMenuRootParams['onHighlightChange'],
+    onHighlightChange: handleHighlightChange,
     closeOnOutsidePress,
     disabled: disabledProp,
   })


### PR DESCRIPTION
## Summary

`onHighlightChange` on the popup-menu families now provides the stable row id first and the resolved menu node second: `(id, node, index, eventDetails)` on `DropdownMenu.Root`, `ContextMenu.Root`, and `Submenu`. `Select` and `Combobox` keep their existing `(id, index, eventDetails)` signatures.

## Changes

- Add the shared generic `PopupMenuHighlightChangeHandler<EventDetails>` type so popup-menu roots, submenus, and internal adapters use one callback interface.
- Wrap store-facing callbacks with `menuTreeResolver.getNodeById(id) ?? null`, preserving the string-based `ListboxStore` interface.
- Keep `id` first because it is available to both JSX and data-first APIs; provide `node` second as nullable resolver enrichment.
- Adapt Select and Combobox internally without changing their public callback interfaces.
- Migrate affected dropdown-menu examples and tests to id-first ordering.
- Cover JSX rows with `node === null` and data-first rows with resolved-node identity assertions.

## Motivation

Events carry nodes per ADR-0001 §4, but popup-menu callbacks also serve JSX-defined rows that have no resolver-owned node. Leading with the universally available `id` keeps the primary identity stable across both authoring modes, while the shared handler type prevents positional drift across package consumers. Builds on #443; #445 builds on this.

## Tests

- `bun run check` (passes with four existing warnings)
- `bun run type-check`
- `bun run test --filter @bazza-ui/react` (40 files, 888 tests at the fully restacked tip)
- JSX callback tests assert id-first ordering with `node === null`.
- Data-first callback tests assert `node.id === id` and `node.def` reference equality.

Closes [UI-467](https://linear.app/bazzalabs/issue/UI-467/onhighlightchange-carries-the-resolved-node)
