### PR TITLE
feat(popup-menu): per-family `Node`/`NodeDef` aliases and node-accepting `content`

### DIFF
--- a/.changeset/family-node-aliases.md
+++ b/.changeset/family-node-aliases.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': minor
+---
+
+Add `DropdownMenu.Node`/`DropdownMenu.NodeDef` (and ContextMenu/CommandMenu equivalents) as pure aliases of the canonical resolved-node types. `Surface` `content` now accepts resolved nodes (`Node[]`) as well as defs.

--- a/packages/react/src/command-menu/index.parts.ts
+++ b/packages/react/src/command-menu/index.parts.ts
@@ -2,6 +2,13 @@
 // Command Menu Parts
 // ============================================================================
 
+// Pure aliases of the canonical resolved-node model (ADR-0001): narrow the
+// alias if a family ever needs to diverge — never edit the canonical type.
+export type {
+  NodeDef,
+  PopupMenuNode as Node,
+} from '../internal/popup-menu/index.js'
+
 export {
   PopupMenuCheckboxItem as CheckboxItem,
   PopupMenuCheckboxItemIndicator as CheckboxItemIndicator,

--- a/packages/react/src/context-menu/index.parts.ts
+++ b/packages/react/src/context-menu/index.parts.ts
@@ -6,6 +6,12 @@
 
 // Re-export VirtualItem type from internal/listbox
 export type { VirtualItem } from '../internal/listbox/index.js'
+// Pure aliases of the canonical resolved-node model (ADR-0001): narrow the
+// alias if a family ever needs to diverge — never edit the canonical type.
+export type {
+  NodeDef,
+  PopupMenuNode as Node,
+} from '../internal/popup-menu/index.js'
 // Re-export shared components from internal/popup-menu
 export {
   PopupMenuArrow as Arrow,

--- a/packages/react/src/dropdown-menu/index.parts.ts
+++ b/packages/react/src/dropdown-menu/index.parts.ts
@@ -6,6 +6,12 @@
 
 // Re-export VirtualItem type from internal/listbox
 export type { VirtualItem } from '../internal/listbox/index.js'
+// Pure aliases of the canonical resolved-node model (ADR-0001): narrow the
+// alias if a family ever needs to diverge — never edit the canonical type.
+export type {
+  NodeDef,
+  PopupMenuNode as Node,
+} from '../internal/popup-menu/index.js'
 // Re-export shared components from internal/popup-menu
 export {
   PopupMenuArrow as Arrow,

--- a/packages/react/src/internal/popup-menu/components/surface/surface.tsx
+++ b/packages/react/src/internal/popup-menu/components/surface/surface.tsx
@@ -39,6 +39,7 @@ import type {
   DataSurfaceProps,
   DeepSearchConfig,
 } from '../../deep-search/types.js'
+import { isPopupMenuNode } from '../../resolve/resolve.js'
 import { getTabbables } from '../../utils/tabbables.js'
 
 // Surface doesn't expose data attributes - using empty state
@@ -174,6 +175,11 @@ export const PopupMenuSurface = React.forwardRef<
     children,
     ...rest
   } = props
+
+  const contentDefs = React.useMemo(
+    () => content?.map((entry) => (isPopupMenuNode(entry) ? entry.def : entry)),
+    [content],
+  )
 
   const isDataMode =
     content !== undefined ||
@@ -313,13 +319,19 @@ export const PopupMenuSurface = React.forwardRef<
   const dataListId = React.useId()
   const dataSurfaceContextValue: DataSurfaceContextValue = React.useMemo(
     () => ({
-      content: content ?? [],
+      content: contentDefs ?? [],
       asyncContent,
       deepSearchConfig,
       includeInDeepSearch,
       listId: dataListId,
     }),
-    [content, asyncContent, deepSearchConfig, includeInDeepSearch, dataListId],
+    [
+      contentDefs,
+      asyncContent,
+      deepSearchConfig,
+      includeInDeepSearch,
+      dataListId,
+    ],
   )
 
   const dataPopupContext = useMaybeDataPopupContext()

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
@@ -2,7 +2,10 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { describe, expect, it, vi } from 'vitest'
+import type { CommandMenu } from '../../../../command-menu/index.js'
+import type { ContextMenu } from '../../../../context-menu/index.js'
 import { DropdownMenu } from '../../../../dropdown-menu/index.js'
+import type { PopupMenuNode } from '../../resolve/types.js'
 import type {
   CheckboxItemDef,
   CheckboxItemRenderParams,
@@ -18,6 +21,21 @@ import type {
   SubmenuRenderParams,
   SubpageDef,
 } from '../types.js'
+
+const resolvedNodeForFamilyAliases = {} as PopupMenuNode
+const nodeDefForFamilyAliases = {} as NodeDef
+const dropdownNodeAlias: DropdownMenu.Node = resolvedNodeForFamilyAliases
+const dropdownNodeDefAlias: DropdownMenu.NodeDef = nodeDefForFamilyAliases
+const contextNodeAlias: ContextMenu.Node = resolvedNodeForFamilyAliases
+const contextNodeDefAlias: ContextMenu.NodeDef = nodeDefForFamilyAliases
+const commandNodeAlias: CommandMenu.Node = resolvedNodeForFamilyAliases
+const commandNodeDefAlias: CommandMenu.NodeDef = nodeDefForFamilyAliases
+void dropdownNodeAlias
+void dropdownNodeDefAlias
+void contextNodeAlias
+void contextNodeDefAlias
+void commandNodeAlias
+void commandNodeDefAlias
 
 // ============================================================================
 // Test Helpers
@@ -1165,6 +1183,61 @@ describe('Subpages', () => {
 })
 
 describe('resolved render params', () => {
+  it('accepts resolved submenu nodes as nested Surface content', async () => {
+    const child = createTestItemDef('nested-content-child', 'Child')
+    let useResolvedContent = false
+    const submenu = createTestSubmenuDef('parent', 'Parent', [child], {
+      render: ({ props, node }) => (
+        <DropdownMenu.Submenu>
+          <DropdownMenu.SubmenuTrigger {...props}>
+            Parent
+          </DropdownMenu.SubmenuTrigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Positioner>
+              <DropdownMenu.Popup>
+                <DropdownMenu.Surface
+                  content={useResolvedContent ? node.children : [child]}
+                >
+                  <DropdownMenu.List>
+                    <ListItems />
+                  </DropdownMenu.List>
+                </DropdownMenu.Surface>
+              </DropdownMenu.Popup>
+            </DropdownMenu.Positioner>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Submenu>
+      ),
+    })
+
+    const { rerender } = render(<MenuWithDataContent content={[submenu]} />)
+    const user = userEvent.setup()
+    await user.hover(screen.getByRole('menuitem'))
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('item-nested-content-child'),
+      ).toBeInTheDocument()
+    })
+    const rawDefIds = [
+      screen.getByTestId('item-nested-content-child').getAttribute('id'),
+    ]
+
+    useResolvedContent = true
+    rerender(<MenuWithDataContent content={[submenu]} />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('item-nested-content-child'),
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('item-nested-content-child')).toHaveTextContent(
+      'Child',
+    )
+    expect([
+      screen.getByTestId('item-nested-content-child').getAttribute('id'),
+    ]).toEqual(rawDefIds)
+  })
+
   it('passes the resolved node to item, submenu, and checkbox renders', () => {
     const defs: NodeDef[] = []
     let itemParams: ItemRenderParams | undefined

--- a/packages/react/src/internal/popup-menu/deep-search/types.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/types.ts
@@ -1318,8 +1318,12 @@ export interface DeepSearchConfig {
  * Props for the DataSurface component.
  */
 export interface DataSurfaceProps {
-  /** The menu content (node definitions with render functions) */
-  content?: NodeDef[]
+  /**
+   * The menu content (node definitions with render functions). Resolved nodes
+   * are accepted anywhere defs are; they are unwrapped to their defs, and
+   * re-supplying the same nodes preserves identity.
+   */
+  content?: NodeDef[] | PopupMenuNode[]
 
   /**
    * Async content configuration for root-level async loading.


### PR DESCRIPTION
## Summary

Adds `DropdownMenu.Node`/`DropdownMenu.NodeDef` (and `ContextMenu`/`CommandMenu` equivalents) as pure aliases of the canonical resolved-node types, and widens `Surface` `content` to accept resolved nodes (`Node[]`) as well as defs.

## Changes

- `dropdown-menu`/`context-menu`/`command-menu` `index.parts.ts`: `export type { PopupMenuNode as Node, NodeDef }` with the ADR-0001 pure-alias comment (narrow the alias to diverge; never edit the canonical type).
- `deep-search/types.ts`: `DataSurfaceProps.content?: NodeDef[] | PopupMenuNode[]`.
- `surface.tsx`: one `contentDefs` memo unwraps resolved nodes (`isPopupMenuNode(entry) ? entry.def : entry`) at the boundary — downstream (filtering, async merge, `dataSurfaceContextValue`, subpages) still sees `NodeDef[]`, and because `entry.def` references are the same objects already in the resolved tree, re-supplying nodes reuses the same instances via the reconcile reference fast path.
- Tests: type-level alias assignments + `accepts resolved submenu nodes as nested Surface content` — a nested surface fed `params.node.children` renders rows with ids identical to the raw-defs baseline.
- Changeset `.changeset/family-node-aliases.md` (`minor`).

## Motivation

Slice 5 of the Parent C breaking swap ([UI-459](https://linear.app/bazzalabs/issue/UI-459/breaking-swap-render-params-and-events-carry-menu-nodes-parent-c)), completing ADR-0001 §1 (per-family pure aliases) and §3 (nested `Surface` content accepts `Node[] | NodeDef[]`). With render params carrying nodes (#443), `content={params.node.children}` becomes the natural way to feed a nested surface. Builds on #444; #446 (docs) is the final slice.

## Tests

- `accepts resolved submenu nodes as nested Surface content` — identity preserved through the unwrap (ids match the defs-passing baseline).
- Compile-time alias assertions against the family barrel.
- Full gates: `bun run check` 0, `bun run type-check` 0, `bun run test --filter @bazza-ui/react` → 878 tests. Adversarial review: zero findings.

Closes [UI-468](https://linear.app/bazzalabs/issue/UI-468/per-family-node-aliases-and-node-accepting-content)
