### PR TITLE
docs(web): migrate menu docs and generated types to the resolved-node API

### DIFF
--- a/apps/web/.types/types-meta.json
+++ b/apps/web/.types/types-meta.json
@@ -2547,10 +2547,10 @@
           },
           {
             "name": "content",
-            "type": "NodeDef[] | undefined",
-            "formattedType": "NodeDef[]",
+            "type": "PopupMenuNode[] | NodeDef[] | undefined",
+            "formattedType": "PopupMenuNode[] | NodeDef[]",
             "required": false,
-            "description": "The menu content (node definitions with render functions)"
+            "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity."
           },
           {
             "name": "render",
@@ -2573,21 +2573,6 @@
             "required": false,
             "description": "Default inclusion mode for descendant branch nodes in deep search results.\nSubmenus/subpages can override via `includeInDeepSearch`.",
             "default": "true"
-          },
-          {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn | undefined",
-            "formattedType": "GetQualifiedRowIdFn",
-            "required": false,
-            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
-            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
-          },
-          {
-            "name": "rowIdStrategy",
-            "type": "RowIdStrategy | undefined",
-            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
-            "required": false,
-            "description": "Named row id strategy. Ignored when `getQualifiedRowId` is provided."
           },
           {
             "name": "asyncContent",
@@ -4284,10 +4269,10 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((id: string | null, index: number, eventDetails: ContextMenuHighlightChangeEventDetails) => void) | undefined",
-            "formattedType": "(\n  id: string | null,\n  index: number,\n  eventDetails: ContextMenuHighlightChangeEventDetails,\n) => void",
+            "type": "((node: PopupMenuNode | null, id: string | null, index: number, eventDetails: ContextMenuHighlightChangeEventDetails) => void) | undefined",
+            "formattedType": "(\n  node: PopupMenuNode | null,\n  id: string | null,\n  index: number,\n  eventDetails: ContextMenuHighlightChangeEventDetails,\n) => void",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\nThe third parameter contains event details including the reason for the change."
+            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\n`node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.\nThe fourth parameter contains event details including the reason for the change."
           },
           {
             "name": "disabled",
@@ -4328,18 +4313,12 @@
             "description": "A ref to imperative actions.\n- `close`: closes the menu imperatively.\n- `unmount`: unmounts the popup imperatively (when keep-mounted mode is enabled).\n- `setDisabled`: enables/disables the menu imperatively."
           },
           {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn | undefined",
-            "formattedType": "GetQualifiedRowIdFn",
+            "name": "getRowId",
+            "type": "GetRowIdFn | undefined",
+            "formattedType": "GetRowIdFn",
             "required": false,
-            "description": "Function to generate qualified unique IDs for rows.\nDefined once at the root level and applied to all surfaces (root and submenus).\n\nDefault behavior:\n- If node.id is provided, use it as-is (treat as globally unique)\n- Otherwise, use the row's full definition path (`defPath`) — identical in\n  browse and deep-search contexts"
-          },
-          {
-            "name": "rowIdStrategy",
-            "type": "RowIdStrategy | undefined",
-            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
-            "required": false,
-            "description": "Named preset for computing data-first row ids. Ignored when `getQualifiedRowId` is provided. Defaults to `'qualified'`."
+            "description": "Computes canonical row ids for data-first content from the unidentified resolved node (definitional facts only).",
+            "default": "explicit `def.id` verbatim, else the joined definition path\nRead once when the menu root mounts — later changes have no effect."
           },
           {
             "name": "debug",
@@ -6108,8 +6087,8 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((id: string | null, index: number) => void) | undefined",
-            "formattedType": "(\n  id: string | null,\n  index: number,\n) => void",
+            "type": "((node: PopupMenuNode | null, id: string | null, index: number, eventDetails: GenericEventDetails<string, { index: number; }>) => void) | undefined",
+            "formattedType": "(\n  node: PopupMenuNode | null,\n  id: string | null,\n  index: number,\n  eventDetails: GenericEventDetails<\n    string,\n    { index: number }\n  >,\n) => void",
             "required": false,
             "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex)."
           },
@@ -6828,10 +6807,10 @@
           },
           {
             "name": "content",
-            "type": "NodeDef[] | undefined",
-            "formattedType": "NodeDef[]",
+            "type": "PopupMenuNode[] | NodeDef[] | undefined",
+            "formattedType": "PopupMenuNode[] | NodeDef[]",
             "required": false,
-            "description": "The menu content (node definitions with render functions)"
+            "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity."
           },
           {
             "name": "asyncContent",
@@ -6854,21 +6833,6 @@
             "required": false,
             "description": "Default inclusion mode for descendant branch nodes in deep search results.\nSubmenus/subpages can override via `includeInDeepSearch`.",
             "default": "true"
-          },
-          {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn | undefined",
-            "formattedType": "GetQualifiedRowIdFn",
-            "required": false,
-            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
-            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
-          },
-          {
-            "name": "rowIdStrategy",
-            "type": "RowIdStrategy | undefined",
-            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
-            "required": false,
-            "description": "Named row id strategy. Ignored when `getQualifiedRowId` is provided."
           }
         ]
       },
@@ -7648,19 +7612,6 @@
             "required": true,
             "description": "When to close the menu on outside interactions.\n- 'pointerdown': Close immediately when pointer is pressed outside (default)\n- 'click': Close when a full click (pointerdown + pointerup) occurs outside",
             "default": "'pointerdown'"
-          },
-          {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn | undefined",
-            "formattedType": "GetQualifiedRowIdFn",
-            "required": false,
-            "description": "Function to generate qualified unique IDs for rows.\nDefined once at the root level and applied to all surfaces (root and submenus).\nIf not provided, uses the default implementation."
-          },
-          {
-            "name": "rowIdStrategy",
-            "type": "RowIdStrategy | undefined",
-            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
-            "required": false
           }
         ]
       },
@@ -8598,7 +8549,7 @@
             "type": "string | undefined",
             "formattedType": "string",
             "required": false,
-            "description": "Unique identifier for this node.\nIf not provided, a composite ID is generated from the `value` and breadcrumbs\nusing the `getItemId` function."
+            "description": "Unique identifier for this node.\nIf provided, it is used verbatim as the resolved row id. If omitted, the\ncanonical id is the node's definition path (ancestor segments plus the\nslugified `value`), or whatever the root `getRowId` seam computes."
           },
           {
             "name": "hidden",
@@ -8666,6 +8617,12 @@
         "kind": "interface",
         "doc": "Parameters passed to checkbox item render functions.",
         "props": [
+          {
+            "name": "node",
+            "type": "PopupMenuNode",
+            "required": true,
+            "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links"
+          },
           {
             "name": "props",
             "type": "CheckboxItemRenderProps",
@@ -8876,20 +8833,6 @@
             "type": "string",
             "required": true,
             "description": "List element ID for aria-activedescendant"
-          },
-          {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn",
-            "formattedType": "(\n  context: GetQualifiedRowIdContext,\n) => string",
-            "required": true,
-            "description": "Function to generate qualified IDs for row items"
-          },
-          {
-            "name": "isLegacyRowIdDefault",
-            "type": "boolean",
-            "formattedType": "false | true",
-            "required": true,
-            "description": "Whether the implicit legacy row id fallback should be preserved"
           }
         ]
       },
@@ -9084,6 +9027,12 @@
           }
         ]
       },
+      "GetRowIdFn": {
+        "name": "GetRowIdFn",
+        "kind": "typealias",
+        "doc": "Computes a node's row id from definitional facts. The id must be unique\nper menu root; it is the identity persistent state, registration, and\nhighlight key off.\n\nContract: the id may read the node's own facts (including its own sibling\n`index`) and may walk `parent` for lineage (as the default definition-path\nrule does), but it must not depend on an *ancestor's* sibling `index` —\nreconciliation invalidates ids by def identity and definition path, not by\nancestor reordering, so ancestor-index-dependent ids would go stale. The\nseam must also not mutate its argument.",
+        "definition": "(node: UnidentifiedMenuNode) => string"
+      },
       "GroupBehavior": {
         "name": "GroupBehavior",
         "kind": "typealias",
@@ -9141,6 +9090,13 @@
         "doc": "Parameters passed to group label render functions.",
         "props": [
           {
+            "name": "node",
+            "type": "PopupMenuNode | undefined",
+            "formattedType": "PopupMenuNode",
+            "required": false,
+            "description": "The resolved menu node for this group. Present when the label is rendered by the library's list; external virtualized wrappers that re-invoke label callbacks may omit it."
+          },
+          {
             "name": "props",
             "type": "{ id: string; }",
             "formattedType": "{ id: string }",
@@ -9194,6 +9150,12 @@
         "kind": "interface",
         "doc": "Parameters passed to group render functions.",
         "props": [
+          {
+            "name": "node",
+            "type": "PopupMenuNode",
+            "required": true,
+            "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links"
+          },
           {
             "name": "props",
             "type": "Record<string, never>",
@@ -9266,7 +9228,7 @@
             "type": "string | undefined",
             "formattedType": "string",
             "required": false,
-            "description": "Unique identifier for this node.\nIf not provided, a composite ID is generated from the `value` and breadcrumbs\nusing the `getItemId` function."
+            "description": "Unique identifier for this node.\nIf provided, it is used verbatim as the resolved row id. If omitted, the\ncanonical id is the node's definition path (ancestor segments plus the\nslugified `value`), or whatever the root `getRowId` seam computes."
           },
           {
             "name": "hidden",
@@ -9340,6 +9302,12 @@
         "doc": "Parameters passed to item render functions.",
         "props": [
           {
+            "name": "node",
+            "type": "PopupMenuNode",
+            "required": true,
+            "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links"
+          },
+          {
             "name": "props",
             "type": "ItemRenderProps",
             "formattedType": "{\n  id: string\n  value: string\n} & Required<Pick<PopupMenu.Item.Props, 'disabled'>> &\n  Pick<\n    PopupMenu.Item.Props,\n    | 'forceOrder'\n    | 'forceScore'\n    | 'shortcut'\n    | 'onSelect'\n    | 'closeOnClick'\n  >",
@@ -9359,13 +9327,13 @@
         "name": "ItemRenderProps",
         "kind": "typealias",
         "doc": "Props to spread onto the Item component.\nDerived from PopupMenuItemProps.",
-        "definition": "{\n    /**\n     * Qualified unique ID for the item.\n     * Must be passed to the rendered component for navigation to work.\n     * This is the computed qualified ID (includes breadcrumb path for deep search results).\n     */\n    id: string;\n    /**\n     * The original value from the node definition.\n     * Use this for display, search matching, or any logic that needs the raw value.\n     */\n    value: string;\n} & Required<Pick<PopupMenuItemProps, 'disabled'>> & Pick<PopupMenuItemProps, 'closeOnClick' | 'onSelect' | 'shortcut' | 'forceOrder' | 'forceScore'>",
+        "definition": "{\n    /**\n     * Canonical resolved row id for the item (explicit `id` verbatim, else the\n     * definition path — identical in browse and deep search).\n     * Must be passed to the rendered component for navigation to work.\n     */\n    id: string;\n    /**\n     * The original value from the node definition.\n     * Use this for display, search matching, or any logic that needs the raw value.\n     */\n    value: string;\n} & Required<Pick<PopupMenuItemProps, 'disabled'>> & Pick<PopupMenuItemProps, 'closeOnClick' | 'onSelect' | 'shortcut' | 'forceOrder' | 'forceScore'>",
         "props": [
           {
             "name": "id",
             "type": "string",
             "required": true,
-            "description": "Qualified unique ID for the item.\nMust be passed to the rendered component for navigation to work.\nThis is the computed qualified ID (includes breadcrumb path for deep search results)."
+            "description": "Canonical resolved row id for the item (explicit `id` verbatim, else the\ndefinition path — identical in browse and deep search).\nMust be passed to the rendered component for navigation to work."
           },
           {
             "name": "value",
@@ -9424,6 +9392,69 @@
         "kind": "typealias",
         "doc": "Union of all node definition types.",
         "definition": "ItemDef | TreeItemDef | RadioItemDef | CheckboxItemDef | SubmenuDef | SubpageDef | SeparatorDef | GroupDef | RadioGroupDef"
+      },
+      "PopupMenuNode": {
+        "name": "PopupMenuNode",
+        "kind": "interface",
+        "doc": "A menu node: the library-created, resolved instance of a node def.\nExactly one per logical row per menu root, in every render context —\nobject identity is row identity, and `id` is its serialization.\nCreated by resolution at the root or by grafting; instances are stable\nacross content re-supplies (reconciliation swaps `def` in place).",
+        "props": [
+          {
+            "name": "def",
+            "type": "NodeDef",
+            "formattedType": "| ItemDef\n  | TreeItemDef\n  | RadioItemDef\n  | CheckboxItemDef\n  | SubmenuDef\n  | SubpageDef\n  | SeparatorDef\n  | GroupDef\n  | RadioGroupDef",
+            "required": true,
+            "description": "The originating def. Replaced in place when content is re-supplied.",
+            "referencePath": "@bazza-ui/react.NodeDef"
+          },
+          {
+            "name": "kind",
+            "type": "\"item\" | \"group\" | \"separator\" | \"checkbox-item\" | \"radio-group\" | \"radio-item\" | \"tree-item\" | \"submenu\" | \"subpage\"",
+            "formattedType": "| 'item'\n  | 'group'\n  | 'separator'\n  | 'checkbox-item'\n  | 'radio-group'\n  | 'radio-item'\n  | 'tree-item'\n  | 'submenu'\n  | 'subpage'",
+            "required": true,
+            "description": "Mirror of `def.kind`, stable for the node's lifetime."
+          },
+          {
+            "name": "segment",
+            "type": "string",
+            "required": true,
+            "description": "This node's path component: explicit `def.id` verbatim when present,\notherwise the slugified `value` (kinds without a display value use\ntheir required `id`; id-less separators have an empty segment)."
+          },
+          {
+            "name": "defPath",
+            "type": "string[]",
+            "required": true,
+            "description": "Definition path: segments from the menu root to this node, including\nits own segment, root-first. Only submenu, subpage, and tree-item\nancestors contribute segments (groups and radio-groups are\npath-transparent). Empty segments are dropped."
+          },
+          {
+            "name": "id",
+            "type": "string",
+            "required": true,
+            "description": "Row id: `def.id` verbatim when present, else `defPath.join('.')`."
+          },
+          {
+            "name": "parent",
+            "type": "PopupMenuNode | null",
+            "formattedType": "null | PopupMenuNode",
+            "required": true
+          },
+          {
+            "name": "children",
+            "type": "PopupMenuNode[]",
+            "required": true
+          },
+          {
+            "name": "depth",
+            "type": "number",
+            "required": true,
+            "description": "Def-tree depth counting every node kind; roots are 0."
+          },
+          {
+            "name": "index",
+            "type": "number",
+            "required": true,
+            "description": "Sibling index in the def tree (position within `parent.children`)."
+          }
+        ]
       },
       "ContextMenuRadioGroupValueProps": {
         "name": "ContextMenuRadioGroupValueProps",
@@ -9539,6 +9570,14 @@
         "doc": "Parameters passed to radio group label render functions.",
         "props": [
           {
+            "name": "node",
+            "type": "PopupMenuNode | undefined",
+            "formattedType": "PopupMenuNode",
+            "required": false,
+            "description": "The resolved menu node for this group. Present when the label is rendered by the library's list; external virtualized wrappers that re-invoke label callbacks may omit it.",
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
+          },
+          {
             "name": "props",
             "type": "{ id: string; }",
             "formattedType": "{ id: string }",
@@ -9560,6 +9599,13 @@
         "kind": "interface",
         "doc": "Parameters passed to radio group render functions.",
         "props": [
+          {
+            "name": "node",
+            "type": "PopupMenuNode",
+            "required": true,
+            "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
+          },
           {
             "name": "props",
             "type": "RadioGroupRenderProps",
@@ -9794,7 +9840,7 @@
             "type": "string | undefined",
             "formattedType": "string",
             "required": false,
-            "description": "Unique identifier for this node.\nIf not provided, a composite ID is generated from the `value` and breadcrumbs\nusing the `getItemId` function."
+            "description": "Unique identifier for this node.\nIf provided, it is used verbatim as the resolved row id. If omitted, the\ncanonical id is the node's definition path (ancestor segments plus the\nslugified `value`), or whatever the root `getRowId` seam computes."
           },
           {
             "name": "hidden",
@@ -9846,6 +9892,13 @@
         "doc": "Parameters passed to submenu render functions.\nIncludes context plus the submenu's child nodes and render function.",
         "props": [
           {
+            "name": "node",
+            "type": "PopupMenuNode",
+            "required": true,
+            "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
+          },
+          {
             "name": "props",
             "type": "SubmenuRenderProps",
             "formattedType": "{\n  id: string\n  value: string\n} & Required<\n  Pick<PopupMenu.SubmenuTrigger.Props, 'disabled'>\n> &\n  Pick<\n    PopupMenu.SubmenuTrigger.Props,\n    'forceOrder' | 'forceScore'\n  >",
@@ -9876,9 +9929,10 @@
           },
           {
             "name": "renderNode",
-            "type": "(node: NodeDef) => ReactNode",
+            "type": "(node: PopupMenuNode | NodeDef) => ReactNode",
+            "formattedType": "(\n  node: PopupMenuNode | NodeDef,\n) => ReactNode",
             "required": true,
-            "description": "Function to render a child node.\nCall this for each node in the submenu's list."
+            "description": "Resolved nodes are unwrapped to their defs."
           }
         ]
       },
@@ -9930,6 +9984,13 @@
         "doc": "Parameters passed to subpage content render functions.\nThe returned JSX should include a `<PopupMenu.Subpage pageId={pageId}>` wrapper.",
         "props": [
           {
+            "name": "node",
+            "type": "PopupMenuNode",
+            "required": true,
+            "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
+          },
+          {
             "name": "pageId",
             "type": "string",
             "required": true,
@@ -9959,9 +10020,10 @@
           },
           {
             "name": "renderNode",
-            "type": "(node: NodeDef) => ReactNode",
+            "type": "(node: PopupMenuNode | NodeDef) => ReactNode",
+            "formattedType": "(\n  node: PopupMenuNode | NodeDef,\n) => ReactNode",
             "required": true,
-            "description": "Function to render a child node.\nCall this for each node in the subpage's list."
+            "description": "Resolved nodes are unwrapped to their defs."
           }
         ]
       },
@@ -10033,7 +10095,7 @@
             "type": "string | undefined",
             "formattedType": "string",
             "required": false,
-            "description": "Unique identifier for this node.\nIf not provided, a composite ID is generated from the `value` and breadcrumbs\nusing the `getItemId` function."
+            "description": "Unique identifier for this node.\nIf provided, it is used verbatim as the resolved row id. If omitted, the\ncanonical id is the node's definition path (ancestor segments plus the\nslugified `value`), or whatever the root `getRowId` seam computes."
           },
           {
             "name": "hidden",
@@ -10084,6 +10146,13 @@
         "kind": "interface",
         "doc": "Parameters passed to subpage trigger render functions.",
         "props": [
+          {
+            "name": "node",
+            "type": "PopupMenuNode",
+            "required": true,
+            "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
+          },
           {
             "name": "props",
             "type": "SubpageTriggerRenderProps",
@@ -10178,7 +10247,7 @@
             "type": "string | undefined",
             "formattedType": "string",
             "required": false,
-            "description": "Unique identifier for this node.\nIf not provided, a composite ID is generated from the `value` and breadcrumbs\nusing the `getItemId` function."
+            "description": "Unique identifier for this node.\nIf provided, it is used verbatim as the resolved row id. If omitted, the\ncanonical id is the node's definition path (ancestor segments plus the\nslugified `value`), or whatever the root `getRowId` seam computes."
           },
           {
             "name": "hidden",
@@ -10245,6 +10314,13 @@
         "doc": "Parameters passed to tree item render functions.",
         "props": [
           {
+            "name": "node",
+            "type": "PopupMenuNode",
+            "required": true,
+            "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
+          },
+          {
             "name": "props",
             "type": "TreeItemRenderProps",
             "formattedType": "Omit<ItemRenderProps, 'shortcut'> & {\n  selectable: boolean\n}",
@@ -10269,7 +10345,7 @@
             "name": "id",
             "type": "string",
             "required": true,
-            "description": "Qualified unique ID for the item.\nMust be passed to the rendered component for navigation to work.\nThis is the computed qualified ID (includes breadcrumb path for deep search results)."
+            "description": "Canonical resolved row id for the item (explicit `id` verbatim, else the\ndefinition path — identical in browse and deep search).\nMust be passed to the rendered component for navigation to work."
           },
           {
             "name": "value",
@@ -10320,6 +10396,66 @@
             "formattedType": "false | true",
             "required": true,
             "description": "Whether this row can be selected."
+          }
+        ]
+      },
+      "UnidentifiedMenuNode": {
+        "name": "UnidentifiedMenuNode",
+        "kind": "typealias",
+        "doc": "A menu node before its row id is assigned — the argument to `GetRowIdFn`.\nCarries definitional facts only (`def`, `segment`, `defPath`, resolved\n`parent`, `depth`, def-tree sibling `index`). Contextual facts (search\nstate, deep-search flags, display position) are deliberately absent:\na context-dependent row id is inexpressible by construction.",
+        "definition": "Omit<PopupMenuNode, 'id'>",
+        "props": [
+          {
+            "name": "index",
+            "type": "number",
+            "required": true,
+            "description": "Sibling index in the def tree (position within `parent.children`)."
+          },
+          {
+            "name": "children",
+            "type": "PopupMenuNode[]",
+            "required": true,
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
+          },
+          {
+            "name": "depth",
+            "type": "number",
+            "required": true,
+            "description": "Def-tree depth counting every node kind; roots are 0."
+          },
+          {
+            "name": "kind",
+            "type": "\"item\" | \"group\" | \"separator\" | \"checkbox-item\" | \"radio-group\" | \"radio-item\" | \"tree-item\" | \"submenu\" | \"subpage\"",
+            "formattedType": "| 'item'\n  | 'group'\n  | 'separator'\n  | 'checkbox-item'\n  | 'radio-group'\n  | 'radio-item'\n  | 'tree-item'\n  | 'submenu'\n  | 'subpage'",
+            "required": true,
+            "description": "Mirror of `def.kind`, stable for the node's lifetime."
+          },
+          {
+            "name": "def",
+            "type": "NodeDef",
+            "formattedType": "| ItemDef\n  | TreeItemDef\n  | RadioItemDef\n  | CheckboxItemDef\n  | SubmenuDef\n  | SubpageDef\n  | SeparatorDef\n  | GroupDef\n  | RadioGroupDef",
+            "required": true,
+            "description": "The originating def. Replaced in place when content is re-supplied.",
+            "referencePath": "@bazza-ui/react.NodeDef"
+          },
+          {
+            "name": "segment",
+            "type": "string",
+            "required": true,
+            "description": "This node's path component: explicit `def.id` verbatim when present,\notherwise the slugified `value` (kinds without a display value use\ntheir required `id`; id-less separators have an empty segment)."
+          },
+          {
+            "name": "defPath",
+            "type": "string[]",
+            "required": true,
+            "description": "Definition path: segments from the menu root to this node, including\nits own segment, root-first. Only submenu, subpage, and tree-item\nancestors contribute segments (groups and radio-groups are\npath-transparent). Empty segments are dropped."
+          },
+          {
+            "name": "parent",
+            "type": "PopupMenuNode | null",
+            "formattedType": "null | PopupMenuNode",
+            "required": true,
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
           }
         ]
       },
@@ -10382,10 +10518,10 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((id: string | null, index: number, eventDetails: DropdownMenuHighlightChangeEventDetails) => void) | undefined",
-            "formattedType": "(\n  id: string | null,\n  index: number,\n  eventDetails: DropdownMenuHighlightChangeEventDetails,\n) => void",
+            "type": "((node: PopupMenuNode | null, id: string | null, index: number, eventDetails: DropdownMenuHighlightChangeEventDetails) => void) | undefined",
+            "formattedType": "(\n  node: PopupMenuNode | null,\n  id: string | null,\n  index: number,\n  eventDetails: DropdownMenuHighlightChangeEventDetails,\n) => void",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\nThe third parameter contains event details including the reason for the change."
+            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\n`node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.\nThe fourth parameter contains event details including the reason for the change."
           },
           {
             "name": "closeOnOutsidePress",
@@ -10410,18 +10546,13 @@
             "description": "A ref to imperative actions.\n- `close`: closes the menu imperatively.\n- `unmount`: unmounts the popup imperatively (when keep-mounted mode is enabled).\n- `setDisabled`: enables/disables the menu imperatively."
           },
           {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn | undefined",
-            "formattedType": "GetQualifiedRowIdFn",
+            "name": "getRowId",
+            "type": "GetRowIdFn | undefined",
+            "formattedType": "GetRowIdFn",
             "required": false,
-            "description": "Function to generate qualified unique IDs for rows.\nDefined once at the root level and applied to all surfaces (root and submenus).\n\nDefault behavior:\n- If node.id is provided, use it as-is (treat as globally unique)\n- Otherwise, use the row's full definition path (`defPath`) — identical in\n  browse and deep-search contexts"
-          },
-          {
-            "name": "rowIdStrategy",
-            "type": "RowIdStrategy | undefined",
-            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
-            "required": false,
-            "description": "Named preset for computing data-first row ids. Ignored when `getQualifiedRowId` is provided. Defaults to `'qualified'`."
+            "description": "Computes canonical row ids for data-first content from the unidentified resolved node (definitional facts only).",
+            "default": "explicit `def.id` verbatim, else the joined definition path\nRead once when the menu root mounts — later changes have no effect.",
+            "referencePath": "@bazza-ui/react.GetRowIdFn"
           },
           {
             "name": "debug",
@@ -12240,8 +12371,8 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((id: string | null, index: number) => void) | undefined",
-            "formattedType": "(\n  id: string | null,\n  index: number,\n) => void",
+            "type": "((node: PopupMenuNode | null, id: string | null, index: number, eventDetails: GenericEventDetails<string, { index: number; }>) => void) | undefined",
+            "formattedType": "(\n  node: PopupMenuNode | null,\n  id: string | null,\n  index: number,\n  eventDetails: GenericEventDetails<\n    string,\n    { index: number }\n  >,\n) => void",
             "required": false,
             "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex)."
           },
@@ -12960,11 +13091,11 @@
           },
           {
             "name": "content",
-            "type": "NodeDef[] | undefined",
-            "formattedType": "NodeDef[]",
+            "type": "PopupMenuNode[] | NodeDef[] | undefined",
+            "formattedType": "PopupMenuNode[] | NodeDef[]",
             "required": false,
-            "description": "The menu content (node definitions with render functions)",
-            "referencePath": "@bazza-ui/react.NodeDef"
+            "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity.",
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
           },
           {
             "name": "asyncContent",
@@ -12988,21 +13119,6 @@
             "description": "Default inclusion mode for descendant branch nodes in deep search results.\nSubmenus/subpages can override via `includeInDeepSearch`.",
             "default": "true",
             "referencePath": "@bazza-ui/react.IncludeInDeepSearch"
-          },
-          {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn | undefined",
-            "formattedType": "GetQualifiedRowIdFn",
-            "required": false,
-            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
-            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
-          },
-          {
-            "name": "rowIdStrategy",
-            "type": "RowIdStrategy | undefined",
-            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
-            "required": false,
-            "description": "Named row id strategy. Ignored when `getQualifiedRowId` is provided."
           }
         ]
       },
@@ -14706,7 +14822,7 @@
             "type": "string | undefined",
             "formattedType": "string",
             "required": false,
-            "description": "Unique identifier for this node.\nIf not provided, a composite ID is generated from the `value` and breadcrumbs\nusing the `getItemId` function."
+            "description": "Unique identifier for this node.\nIf provided, it is used verbatim as the resolved row id. If omitted, the\ncanonical id is the node's definition path (ancestor segments plus the\nslugified `value`), or whatever the root `getRowId` seam computes."
           },
           {
             "name": "hidden",
@@ -14780,6 +14896,13 @@
         "kind": "interface",
         "doc": "Parameters passed to radio item render functions.",
         "props": [
+          {
+            "name": "node",
+            "type": "PopupMenuNode",
+            "required": true,
+            "description": "The resolved menu node for this row — canonical identity (`node.id`), definition path, and tree links",
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
+          },
           {
             "name": "props",
             "type": "RadioItemRenderProps",
@@ -16683,11 +16806,11 @@
           },
           {
             "name": "content",
-            "type": "NodeDef[] | undefined",
-            "formattedType": "NodeDef[]",
+            "type": "PopupMenuNode[] | NodeDef[] | undefined",
+            "formattedType": "PopupMenuNode[] | NodeDef[]",
             "required": false,
-            "description": "The menu content (node definitions with render functions)",
-            "referencePath": "@bazza-ui/react.NodeDef"
+            "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity.",
+            "referencePath": "@bazza-ui/react.PopupMenuNode"
           },
           {
             "name": "render",
@@ -16711,21 +16834,6 @@
             "description": "Default inclusion mode for descendant branch nodes in deep search results.\nSubmenus/subpages can override via `includeInDeepSearch`.",
             "default": "true",
             "referencePath": "@bazza-ui/react.IncludeInDeepSearch"
-          },
-          {
-            "name": "getQualifiedRowId",
-            "type": "GetQualifiedRowIdFn | undefined",
-            "formattedType": "GetQualifiedRowIdFn",
-            "required": false,
-            "description": "Function to generate qualified IDs for row items.\nCalled for each item when rendering to produce IDs for:\n- React keys\n- Store registration\n- DOM id attributes",
-            "default": "Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value"
-          },
-          {
-            "name": "rowIdStrategy",
-            "type": "RowIdStrategy | undefined",
-            "formattedType": "\"qualified\" | \"explicit\" | \"hybrid\"",
-            "required": false,
-            "description": "Named row id strategy. Ignored when `getQualifiedRowId` is provided."
           },
           {
             "name": "asyncContent",

--- a/apps/web/content/docs/dropdown-menu/api-reference.mdx
+++ b/apps/web/content/docs/dropdown-menu/api-reference.mdx
@@ -15,6 +15,10 @@ Groups all parts of the dropdown menu. Manages open state and provides context t
 
 <TypeTableAuto type="DropdownMenuRootProps" pkg="@bazza-ui/react" />
 
+### onHighlightChange
+
+Called as `(node, id, index, eventDetails)` when the highlighted row changes. `node` is the resolved menu node looked up by `id` in the data-first tree, or `null` for JSX-defined rows and when the highlight clears.
+
 ## Trigger
 
 A button that opens the dropdown menu. Renders a `<button>` element.
@@ -320,16 +324,19 @@ These types are used to define menu content when using the Data-First API.
 
 ### NodeDef
 
-Union type of all possible node definitions. Import and use to type your menu content arrays.
+Union type of all possible node definitions. `DropdownMenu.NodeDef` is the namespaced alias. `DropdownMenu.Node` is the corresponding resolved-node alias. Import and use `NodeDef` to type your menu content arrays.
 
 ```tsx
-import type { NodeDef } from '@bazza-ui/react'
+import type { NodeDef, PopupMenuNode } from '@bazza-ui/react/dropdown-menu'
+// or via the namespace: DropdownMenu.NodeDef / DropdownMenu.Node
 
 const content: NodeDef[] = [
   { kind: 'item', value: 'Copy', render: ... },
   { kind: 'submenu', value: 'More', nodes: [...], render: ... },
   { kind: 'separator' },
 ]
+
+// Resolved nodes are available in render parameters as Node.
 ```
 
 <TypeTableAuto type="NodeDef" pkg="@bazza-ui/react" />
@@ -384,13 +391,13 @@ These types are passed to the `render` function of each node definition.
 
 ### ItemRenderParams
 
-Parameters passed to `ItemDef.render()`.
+Parameters passed to `ItemDef.render()`. The `node` member is the resolved menu node, including its canonical `id`, `defPath`, and `parent`/`children` relationships.
 
 ```tsx
 {
   kind: 'item',
   value: 'Copy',
-  render: ({ props, context }) => {
+  render: ({ props, node, context }) => {
     // props: { id, value, disabled, closeOnClick?, onSelect?, shortcut? }
     // context: { highlighted, disabled, search, breadcrumbs, isDeepSearchResult, group }
     return <DropdownMenu.Item {...props}>Copy</DropdownMenu.Item>
@@ -402,18 +409,19 @@ Parameters passed to `ItemDef.render()`.
 
 ### SubmenuRenderParams
 
-Parameters passed to `SubmenuDef.render()`.
+Parameters passed to `SubmenuDef.render()`. The `node` member is the resolved menu node, including its canonical `id`, `defPath`, and `parent`/`children` relationships.
 
 ```tsx
 {
   kind: 'submenu',
   value: 'More Options',
   nodes: [...],
-  render: ({ props, context, nodes, renderNode }) => {
+  render: ({ props, node, context, nodes, renderNode }) => {
     // props: { id, value, disabled }
     // context: { highlighted, disabled, search, breadcrumbs, isDeepSearchResult, async? }
+    // node: Node - the resolved submenu node
     // nodes: NodeDef[] - child nodes to render
-    // renderNode: (node: NodeDef) => ReactNode - function to render a child node
+    // renderNode: (node: NodeDef | Node) => ReactNode - function to render a child node
     return (
       <DropdownMenu.Submenu>
         <DropdownMenu.SubmenuTrigger {...props}>...</DropdownMenu.SubmenuTrigger>
@@ -428,25 +436,25 @@ Parameters passed to `SubmenuDef.render()`.
 
 ### CheckboxItemRenderParams
 
-Parameters passed to `CheckboxItemDef.render()`.
+Parameters passed to `CheckboxItemDef.render()`. The `node` member is the resolved menu node, including its canonical `id`, `defPath`, and `parent`/`children` relationships.
 
 <TypeTableAuto type="CheckboxItemRenderParams" pkg="@bazza-ui/react" />
 
 ### RadioItemRenderParams
 
-Parameters passed to `RadioItemDef.render()`.
+Parameters passed to `RadioItemDef.render()`. The `node` member is the resolved menu node, including its canonical `id`, `defPath`, and `parent`/`children` relationships.
 
 <TypeTableAuto type="RadioItemRenderParams" pkg="@bazza-ui/react" />
 
 ### GroupRenderParams
 
-Parameters passed to `GroupDef.render()`.
+Parameters passed to `GroupDef.render()`. The `node` member is the resolved menu node, including its canonical `id`, `defPath`, and `parent`/`children` relationships.
 
 <TypeTableAuto type="GroupRenderParams" pkg="@bazza-ui/react" />
 
 ### RadioGroupRenderParams
 
-Parameters passed to `RadioGroupDef.render()`.
+Parameters passed to `RadioGroupDef.render()`. The `node` member is the resolved menu node, including its canonical `id`, `defPath`, and `parent`/`children` relationships.
 
 <TypeTableAuto type="RadioGroupRenderParams" pkg="@bazza-ui/react" />
 
@@ -460,7 +468,7 @@ Represents a submenu in the breadcrumb path. Used in render context to show wher
 
 ```tsx
 interface BreadcrumbNode {
-  node: SubmenuDef  // The full submenu definition
+  node: SubmenuDef | SubpageDef | TreeItemDef  // The full submenu definition
   value: string     // The submenu's value
   id?: string       // The submenu's explicit id (if provided)
 }
@@ -485,10 +493,16 @@ Configuration options for deep search behavior.
 - `stream` (default): show available rows immediately and append later async batches without reordering earlier rows.
 - `block`: show loading-only state until all participating async loaders resolve, then render the full sorted result set.
 
-### GetQualifiedRowIdFn
+### GetRowIdFn
 
-Function type for custom ID generation. Passed to `Root` or data-first `Surface` via the `getQualifiedRowId` prop. When provided, this function takes precedence over `rowIdStrategy`.
+Function type for `getRowId` on `Root`. It receives the unidentified resolved node (`UnidentifiedMenuNode` — the resolved node without its `id`) and is read once at mount. The node carries only definitional facts: `def`, `kind`, `segment`, `defPath`, `parent`, `depth`, `index`, and `children` (empty at id-computation time). Render-context facts (search state, display position) are excluded by construction.
 
-`rowIdStrategy` controls data-first row IDs and accepts `'qualified'`, `'explicit'`, or `'hybrid'`. It defaults to `'qualified'`, where id-less rows are identified by their full definition path (ancestor branch segments — submenus and tree items — plus their slugified value), identical in browse and deep-search contexts. Rows rendered inside subpages currently derive their ids independently of `rowIdStrategy`. `'explicit'` requires rows to declare explicit `id`s; when a row has none, it warns in development and falls back to the qualified ID. Use `'hybrid'` to restore the legacy behavior, where paths are included only during deep search.
+```tsx
+<DropdownMenu.Root getRowId={(node) => node.def.id ?? node.defPath.join('.')}>
+  {/* ... */}
+</DropdownMenu.Root>
+```
 
-<TypeTableAuto type="GetQualifiedRowIdFn" pkg="@bazza-ui/react" />
+By default, `getRowId` returns explicit `def.id` values verbatim, or `defPath.join('.')` when no explicit id is provided. The former `'qualified'` behavior is now the default behavior of `getRowId`. `'explicit'` is a consumer-authored seam that requires `node.def.id`; `'hybrid'` has no successor because ids no longer depend on render context.
+
+<TypeTableAuto type="GetRowIdFn" pkg="@bazza-ui/react" />

--- a/packages/react/src/internal/popup-menu/deep-search/types.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/types.ts
@@ -366,9 +366,9 @@ export interface RowRenderContext {
  */
 export type ItemRenderProps = {
   /**
-   * Qualified unique ID for the item.
+   * Canonical resolved row id for the item (explicit `id` verbatim, else the
+   * definition path — identical in browse and deep search).
    * Must be passed to the rendered component for navigation to work.
-   * This is the computed qualified ID (includes breadcrumb path for deep search results).
    */
   id: string
   /**
@@ -756,8 +756,9 @@ export interface RadioGroupLabelRenderParams {
 interface BaseNodeDef {
   /**
    * Unique identifier for this node.
-   * If not provided, a composite ID is generated from the `value` and breadcrumbs
-   * using the `getItemId` function.
+   * If provided, it is used verbatim as the resolved row id. If omitted, the
+   * canonical id is the node's definition path (ancestor segments plus the
+   * slugified `value`), or whatever the root `getRowId` seam computes.
    */
   id?: string
   /** Whether this node is hidden */
@@ -1381,16 +1382,6 @@ export interface DataSurfaceProps {
    * @default true
    */
   resetScrollOnSearch?: boolean
-
-  /**
-   * Function to generate qualified IDs for row items.
-   * Called for each item when rendering to produce IDs for:
-   * - React keys
-   * - Store registration
-   * - DOM id attributes
-   *
-   * @default Uses node.id if provided, otherwise qualifies with breadcrumbs + slugified value
-   */
 
   /** Children (Input, List, etc.) */
   children: React.ReactNode


### PR DESCRIPTION
## Summary

Migrates the menu documentation and generated type metadata to the resolved-node API, closing out the Parent C breaking swap.

## Changes

- `apps/web/content/docs/dropdown-menu/api-reference.mdx`: `### GetQualifiedRowIdFn` → `### GetRowIdFn` (unidentified resolved node, mount-static, default `def.id ?? defPath.join('.')`, example included) with a migration note (`'qualified'` = the default; `'explicit'` = consumer-authored seam requiring `node.def.id`; `'hybrid'` has **no successor**); every render-params section documents the `node` member and both inline samples destructure it; new `### onHighlightChange` note for the `(node, id, index, eventDetails)` signature; `DropdownMenu.Node`/`DropdownMenu.NodeDef` aliases mentioned where `NodeDef` is introduced; `BreadcrumbNode` example corrected to `SubmenuDef | SubpageDef | TreeItemDef`.
- `packages/react/src/internal/popup-menu/deep-search/types.ts` (JSDoc only): `BaseNodeDef.id` and `ItemRenderProps.id` docs rewritten for the resolved-id model (the old text taught the deleted `getItemId`/breadcrumb composite model); an orphaned JSDoc block left over from the `getQualifiedRowId` field deletion removed.
- `apps/web/.types/types-meta.json`: regenerated (`bun run docs:type-gen`) — zero `GetQualifiedRowIdContext`/`getItemId` remnants, `GetRowIdFn` present. `bun run registry:build` re-run; outputs byte-identical (no registry-base sources changed in this stack).

## Motivation

Slice 6 of 6 of the Parent C breaking swap ([UI-459](https://linear.app/bazzalabs/issue/UI-459/breaking-swap-render-params-and-events-carry-menu-nodes-parent-c)) — the docs must describe the API the stack now ships (#441–#445): consumers following the reference otherwise hit TypeScript errors against deleted symbols. `Select`/`Combobox` docs are deliberately untouched (their signatures didn't change). Builds on #445.

Note: `TypeTableAuto` renders alias/function types (like `GetRowIdFn` and `NodeDef`) without a property table — identical to the pre-existing behavior for `GetQualifiedRowIdFn`; the section's prose + code sample carry the signature (recorded, pre-existing renderer behavior).

## Tests

No automated coverage — docs content and generated metadata; `apps/web` has no test harness for mdx. Verified by: `bun run docs:type-gen` and `bun run registry:build` exit 0; `grep` gates (`getQualifiedRowId|rowIdStrategy` → 0 in docs, `GetQualifiedRowIdContext`/`getItemId` → 0 in `types-meta.json`); full `bun run check`/`bun run type-check`/`bun run test --filter @bazza-ui/react` (878) all green.

Closes [UI-469](https://linear.app/bazzalabs/issue/UI-469/migrate-menu-docs-and-generated-types-to-resolved-nodes)
