### PR TITLE
refactor(popup-menu): share `getAsyncLoaderIdForBranch`

### DIFF
--- a/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
@@ -5,7 +5,6 @@ import {
   useListboxContext,
   type useSurfaceContext,
 } from '../../listbox/index.js'
-import { normalizeValue } from '../../listbox/utils/normalize.js'
 import { PopupMenuGroupLabel } from '../components/group-label/group-label.js'
 import {
   PopupMenuListPrimitive,
@@ -60,6 +59,7 @@ import {
   type AsyncSubmenuInfo,
   collectAsyncSubmenus,
   filterNodes,
+  getAsyncLoaderIdForBranch,
   getSubpagePageId,
   mergeAsyncNodesIntoTree,
   shouldLoadEagerly,
@@ -308,16 +308,6 @@ function resolveQueryExecutionState(
     enabled: false,
     isBelowMinLength: true,
   }
-}
-
-function getAsyncLoaderIdForBranch(
-  node: SubmenuDef | SubpageDef,
-  breadcrumbs: BreadcrumbNode[],
-): string {
-  return [
-    ...breadcrumbs.map((breadcrumb) => normalizeValue(breadcrumb.value)),
-    normalizeValue(node.value),
-  ].join('.')
 }
 
 /**

--- a/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import * as React from 'react'
-import { normalizeValue } from '../../listbox/utils/normalize.js'
 import { useMenuTreeResolver } from '../contexts/menu-tree-resolver-context.js'
 import {
   defaultGetRowId,
@@ -29,7 +28,7 @@ import type {
   SubmenuDef,
   SubpageDef,
 } from './types.js'
-import { getSubpagePageId } from './utils.js'
+import { getAsyncLoaderIdForBranch, getSubpagePageId } from './utils.js'
 
 interface QueryExecutionState {
   effectiveQuery: string
@@ -88,16 +87,6 @@ function resolveQueryExecutionState(
     enabled: false,
     isBelowMinLength: true,
   }
-}
-
-function getAsyncLoaderIdForBranch(
-  node: SubmenuDef | SubpageDef,
-  breadcrumbs: BreadcrumbNode[],
-): string {
-  return [
-    ...breadcrumbs.map((breadcrumb) => normalizeValue(breadcrumb.value)),
-    normalizeValue(node.value),
-  ].join('.')
 }
 
 function getBranchAsyncState(

--- a/packages/react/src/internal/popup-menu/deep-search/utils.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/utils.ts
@@ -78,6 +78,22 @@ export function getSubpagePageId(
   return path ? `subpage.${path}` : 'subpage'
 }
 
+/**
+ * Path key for a branch's async loader. **Value-only by design** — breadcrumb
+ * and leaf `value`s, normalized and dot-joined; explicit `id`s are deliberately
+ * ignored. Must stay consistent with the key computations inside
+ * `collectAsyncSubmenus` and `mergeAsyncNodesIntoTree`.
+ */
+export function getAsyncLoaderIdForBranch(
+  node: SubmenuDef | SubpageDef,
+  breadcrumbs: BreadcrumbNode[],
+): string {
+  return [
+    ...breadcrumbs.map((breadcrumb) => normalizeValue(breadcrumb.value)),
+    normalizeValue(node.value),
+  ].join('.')
+}
+
 // ============================================================================
 // Type Guards
 // ============================================================================
@@ -1654,6 +1670,7 @@ export function collectAsyncSubmenus(
 
       // If this branch has async nodes, add it to the result
       if (node.asyncNodes && shouldIncludeBranchDescendants) {
+        // Must match getAsyncLoaderIdForBranch's value-only path-key scheme.
         const id = [...breadcrumbs, normalizeValue(node.value)].join('.')
         result.push({
           id,
@@ -1731,6 +1748,7 @@ export function mergeAsyncNodesIntoTree(
   ): NodeDef[] {
     return nodes.map((node) => {
       if (node.kind === 'submenu' || node.kind === 'subpage') {
+        // Must match getAsyncLoaderIdForBranch's value-only path-key scheme.
         const branchPath = [
           ...currentBreadcrumbs,
           normalizeValue(node.value),


### PR DESCRIPTION
## Summary

Collapses the two byte-identical local `getAsyncLoaderIdForBranch` definitions into one shared export in `deep-search/utils.ts`, and documents the value-only async path-key contract at every remaining computation site.

## Changes

- `deep-search/utils.ts`: exported `getAsyncLoaderIdForBranch` (body byte-identical to the deleted copies), JSDoc stating the contract — value-only by design (breadcrumb + leaf `value`s, normalized and dot-joined; explicit `id`s deliberately ignored), must stay consistent with `collectAsyncSubmenus` and `mergeAsyncNodesIntoTree`; one-line consistency comments added at those two inline key computations.
- `deep-search/data-list.tsx` / `data-subpages.tsx`: local copies deleted; import from `./utils.js`; usages unchanged; now-unused `normalizeValue`/`slugify` import dropped from `data-list.tsx`.
- Not exported from any barrel; no key-scheme change; no changeset (internal-only).

## Motivation

Slice 1 of Parent D ([UI-460](https://linear.app/bazzalabs/issue/UI-460/unification-dividends-subpages-async-ids-barrel-narrowing-parent-d)): four independent implementations of the async loader path-key scheme had to stay bit-for-bit consistent for loader results to be found; this removes two of them and pins the contract in writing at the rest. Builds on #446; #448 and #449 stack on this.

Scope note (recorded on the issue): the banked async-subpage-inside-a-submenu regression test was descoped after a second executor attempt — the flow (submenu `asyncNodes` loader returning a subpage def, then activating that subpage) cannot be driven reliably in this jsdom harness (worker timeouts/OOM). The coverage obligation moves to [UI-473](https://linear.app/bazzalabs/issue/UI-473/unify-the-subpage-render-path-with-the-data-list-pipeline), where the subpage render path gets restructured with a testable seam.

## Tests

No new tests (the planned regression test was descoped, see Motivation). Behavior-neutrality is covered by the existing async suite: `bun run check` 0, `bun run type-check` 0, `bun run test --filter @bazza-ui/react` → 878 tests pass unchanged. Adversarial review: 1 minor finding (unused import), fixed.

Closes [UI-470](https://linear.app/bazzalabs/issue/UI-470/share-getasyncloaderidforbranch-cover-async-subpages-in-submenus)
