### PR TITLE
feat(popup-menu): align `getSubpagePageId` with the canonical segment rule

### DIFF
--- a/.changeset/subpage-page-id-rule.md
+++ b/.changeset/subpage-page-id-rule.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': minor
+---
+
+**Behavior change.** Subpage page ids now follow the canonical segment rule — explicit `id`s pass through verbatim instead of being slugified (`subpage.My.Page` where the id is `"My.Page"`; previously `subpage.mypage`). Ids without explicit `id`, and explicit `pageId` props, are unaffected. Update any hardcoded `targetPageId`/`pageId` strings that relied on slugified explicit ids.

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/get-subpage-page-id.test.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/get-subpage-page-id.test.ts
@@ -1,0 +1,83 @@
+import { getSubpagePageId } from '../utils.js'
+
+function subpage(
+  value: string,
+  options: Pick<SubpageDef, 'id' | 'pageId'> = {},
+): SubpageDef {
+  return {
+    kind: 'subpage',
+    value,
+    nodes: [],
+    renderTrigger: () => null,
+    renderContent: () => null,
+    ...options,
+  }
+}
+
+function breadcrumb(value: string, id?: string) {
+  return {
+    node: subpage(value, id === undefined ? {} : { id }),
+    value,
+    ...(id === undefined ? {} : { id }),
+  }
+}
+
+describe('getSubpagePageId', () => {
+  it('uses an explicit pageId verbatim', () => {
+    expect(
+      getSubpagePageId(subpage('Settings', { pageId: 'custom.Page' }), []),
+    ).toBe('custom.Page')
+  })
+
+  it('slugifies an id-less subpage value', () => {
+    expect(getSubpagePageId(subpage('Account Settings'), [])).toBe(
+      'subpage.account-settings',
+    )
+  })
+
+  it('passes an explicit slug-shaped id through verbatim', () => {
+    expect(
+      getSubpagePageId(
+        subpage('Account Settings', { id: 'account-settings' }),
+        [],
+      ),
+    ).toBe('subpage.account-settings')
+  })
+
+  it('passes an explicit non-slug id through verbatim', () => {
+    expect(
+      getSubpagePageId(subpage('Account Settings', { id: 'My.Page' }), []),
+    ).toBe('subpage.My.Page')
+  })
+
+  it('uses breadcrumb ids verbatim and slugifies id-less breadcrumb values', () => {
+    expect(
+      getSubpagePageId(subpage('Current Page'), [
+        breadcrumb('Parent Value'),
+        breadcrumb('Another Value', 'Parent.Page'),
+      ]),
+    ).toBe('subpage.parent-value.Parent.Page.current-page')
+  })
+
+  it('drops empty breadcrumb and leaf segments', () => {
+    expect(
+      getSubpagePageId(subpage('', { id: '' }), [
+        breadcrumb('', ''),
+        breadcrumb('Visible Value'),
+      ]),
+    ).toBe('subpage.visible-value')
+  })
+
+  it('drops an empty explicit id even when the value is non-empty (canonical empty-segment rule)', () => {
+    // Per the canonical Segment rule, an explicit id is used verbatim — an
+    // empty-string id therefore resolves to an empty segment, which is
+    // dropped from the path (matching resolver defPath semantics). Consumers
+    // must omit `id` (not pass '') to fall back to the slugified value.
+    expect(getSubpagePageId(subpage('Settings', { id: '' }), [])).toBe(
+      'subpage',
+    )
+    expect(
+      getSubpagePageId(subpage('Settings', { id: '' }), [breadcrumb('Parent')]),
+    ).toBe('subpage.parent')
+  })
+})

--- a/packages/react/src/internal/popup-menu/deep-search/utils.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/utils.ts
@@ -59,7 +59,8 @@ export function computeDefPath(
  *
  * Priority:
  * - explicit `node.pageId`
- * - derived from breadcrumb ids/values + node id/value (slugified)
+ * - derived from breadcrumb and node segments following the canonical rule:
+ *   explicit `id` verbatim, otherwise slugified `value`
  */
 export function getSubpagePageId(
   node: SubpageDef,
@@ -70,9 +71,9 @@ export function getSubpagePageId(
   }
 
   const breadcrumbSegments = breadcrumbs
-    .map((breadcrumb) => slugify(breadcrumb.id ?? breadcrumb.value))
+    .map((breadcrumb) => breadcrumb.id ?? slugify(breadcrumb.value))
     .filter(Boolean)
-  const leafSegment = slugify(node.id ?? node.value)
+  const leafSegment = node.id ?? slugify(node.value)
   const path = [...breadcrumbSegments, leafSegment].filter(Boolean).join('.')
 
   return path ? `subpage.${path}` : 'subpage'


### PR DESCRIPTION
## Summary

`getSubpagePageId` adopts the canonical segment rule: each segment is now explicit `id` verbatim, else `slugify(value)` — replacing the old `slugify(id ?? value)` dialect, the last id formula in the popup-menu system that disagreed with the resolved-node model.

## Changes

- `deep-search/utils.ts`: breadcrumb segments become `breadcrumb.id ?? slugify(breadcrumb.value)` and the leaf becomes `node.id ?? slugify(node.value)`; explicit `pageId` short-circuit, `.filter(Boolean)`, dot-join, and the `subpage.` prefix unchanged. JSDoc updated.
- New `deep-search/__tests__/get-subpage-page-id.test.ts` (7 cases — first-ever unit coverage for this function): `pageId` wins; id-less slugification; slug-shaped id verbatim; non-slug id (`"My.Page"`) verbatim (the deliberate change); breadcrumb rule; empty segments dropped; and an explicit pin of the canonical empty-id semantics (`id: ''` resolves to an empty segment and is dropped — omit `id`, don't pass `''`).
- Changeset `.changeset/subpage-page-id-rule.md` (`minor`, behavior-change voiced).

## Motivation

Slice 2 of Parent D ([UI-460](https://linear.app/bazzalabs/issue/UI-460/unification-dividends-subpages-async-ids-barrel-narrowing-parent-d)). The banked planning note required this to be a deliberate, documented change — never a silent unification side effect. Only explicit ids that aren't slug-shaped diverge (`id: "My.Page"` → `subpage.My.Page`, previously `subpage.mypage`); trigger↔page matching is unaffected because both call sites use symmetric breadcrumb inputs. Builds on #447; #449 stacks on this.

Recorded accepted edges (same tradeoffs the canonical row-id model already documents): verbatim ids containing dots can produce ambiguous dot-joined paths (as with row `defPath`s — ids are expected to be unique and dot-free by convention), and empty-string explicit ids resolve to dropped segments (matching resolver `defPath` semantics, now pinned by a dedicated test).

## Tests

- 7 unit cases in `get-subpage-page-id.test.ts`; the `My.Page` and breadcrumb-rule cases fail under the old formula (verified by the adversarial reviewer's analysis).
- No integration expectations changed (existing fixtures use slug-shaped ids only).
- Full gates: `bun run check` 0, `bun run type-check` 0, `bun run test --filter @bazza-ui/react` → 885 tests.

Closes [UI-471](https://linear.app/bazzalabs/issue/UI-471/align-getsubpagepageid-with-the-canonical-segment-rule)
