### PR TITLE
refactor(popup-menu)!: rename `segment` to `pathSegment` and `resolve/` to `menu-tree/`

### DIFF
--- a/.changeset/path-segment-and-menu-tree.md
+++ b/.changeset/path-segment-and-menu-tree.md
@@ -1,0 +1,7 @@
+---
+'@bazza-ui/react': minor
+---
+
+**Breaking change.** `PopupMenuNode.segment` is now `PopupMenuNode.pathSegment`, a node's own component of its definition path; it equals the row id only when the def carries an explicit `id`. Custom `getRowId` implementations reading `node.segment` must update.
+
+The internal directory rename (`resolve/` → `menu-tree/`) is not public surface — the `@bazza-ui/react/internal/popup-menu` barrel exports the same symbol names from the same subpath.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,61 @@
+# Popup Menu (data-first)
+
+The data-first popup-menu system in `@bazza-ui/react`: consumers describe menu content as declarative node definitions; the library resolves them into menu nodes, then renders, filters, deep-searches, and identifies rows.
+
+Where it lives (`packages/react/src/internal/popup-menu/`):
+
+- `menu-tree/` — the resolved-node model and the resolver (identity, reconcile, graft)
+- `data-first/` — the pipeline that renders defs: list, subpages, filtering/deep search, async
+- `components/`, `contexts/`, `hooks/` — the JSX parts and their plumbing
+
+## Language
+
+**Node Def**:
+A user-authored, declarative description of one menu entry (item, checkbox item, radio item, submenu, subpage, tree item, group, separator). Plain data; never mutated by the library.
+_Avoid_: node config, definition object
+
+**Menu Node**:
+The library-created, resolved instance of a node def — carries identity (row id, path segment, definition path), tree links (parent, children), and a reference to its originating def. Exactly one per logical row per menu root, in every render context; created by resolution at the root, or by grafting. Surfaced to consumers as `Node` under each family namespace.
+_Avoid_: resolved node (as a noun — "resolution" stays as the process), wrapper, instance
+
+**Menu Tree**:
+The single resolved node tree owned by one menu root, and the `MenuTreeResolver` that maintains it. Created once per root; re-supplied content reconciles into it rather than rebuilding it.
+_Avoid_: node graph, model
+
+**Display Node**:
+The render-scoped wrapper the pipeline builds from node defs for one surface's current render (filtering, scoring, grouping applied). Rebuilt per render; context-dependent.
+_Avoid_: row wrapper
+
+**Segment** (field: `pathSegment`):
+A node's single path component: its explicit id verbatim when present, otherwise its slugified value. A segment is not necessarily slug-shaped (explicit ids pass through untouched); segments that resolve to empty are dropped from paths. The concept is "segment"; the field is named `pathSegment` because a bare `segment` reads as a synonym for the row id (they are in fact equal whenever a def carries an explicit id).
+_Avoid_: slug, key, part
+
+**Definition Path** (`defPath`):
+The segments from the menu root to a node in the definition tree, including the node's own segment. Identical wherever the node renders — browse, deep search, or recursion. The canonical identity path.
+_Avoid_: absolute path, tree path, full path, ancestor path
+
+**Breadcrumbs**:
+The branch nodes walked by the displaying surface to reach a row within its own render pass. Carries rich node references, not just segments.
+_Avoid_: trail, crumb path
+
+**Browse / Deep Search**:
+The two render contexts: browsing renders each surface's own nodes in place; deep search flattens a subtree into the searching surface as results. A row's identity must not depend on which context displays it.
+
+**Row Id**:
+The unique identity of a menu node — the value persistent state, registration, and highlight key off. Produced once per node by `getRowId` (default: explicit id verbatim, else the joined definition path). Definitional and context-free: a row id never depends on how or where the row is rendered. Context-dependent ids are inexpressible by construction — `getRowId` receives only definitional facts.
+_Avoid_: composite id, qualified id
+
+**Graft**:
+Resolving node defs that arrive after mount (async loader results; render-time content) and attaching the resulting nodes under an already-resolved parent — the graft point — so they join the single resolved tree with correct lineage (definition path, row id).
+_Avoid_: merge, inject, append
+
+**Detached Node**:
+The stable placeholder node produced for a def that is rendered but is not part of the resolved tree (a consumer passing an arbitrary def to `renderNode`). Dev-warned once per def; its id is root-relative rather than path-qualified. Not a supported authoring pattern — memoize defs and prefer explicit ids.
+_Avoid_: orphan node, temp node
+
+## Removed vocabulary
+
+These terms described the string-based identity model and no longer exist in the code. They appear here only so the names are not reintroduced with new meanings.
+
+- **Row Id Strategy** (`rowIdStrategy`: `qualified` / `explicit` / `hybrid`) and `getQualifiedRowId` — superseded by the `getRowId` seam. `hybrid` has no successor: it made ids depend on render context, which the resolved-node model forbids by construction.
+- **Display Path** (`displayPath`) — the segments of the submenus enclosing the surface a row was displayed in. Contextual by nature; deleted along with the strategy machinery that consumed it.

--- a/apps/web/.types/types-meta.json
+++ b/apps/web/.types/types-meta.json
@@ -9414,10 +9414,10 @@
             "description": "Mirror of `def.kind`, stable for the node's lifetime."
           },
           {
-            "name": "segment",
+            "name": "pathSegment",
             "type": "string",
             "required": true,
-            "description": "This node's path component: explicit `def.id` verbatim when present,\notherwise the slugified `value` (kinds without a display value use\ntheir required `id`; id-less separators have an empty segment)."
+            "description": "This node's path component: explicit `def.id` verbatim when present,\notherwise the slugified `value` (kinds without a display value use\ntheir required `id`; id-less separators have an empty path segment)."
           },
           {
             "name": "defPath",
@@ -10402,7 +10402,7 @@
       "UnidentifiedMenuNode": {
         "name": "UnidentifiedMenuNode",
         "kind": "typealias",
-        "doc": "A menu node before its row id is assigned — the argument to `GetRowIdFn`.\nCarries definitional facts only (`def`, `segment`, `defPath`, resolved\n`parent`, `depth`, def-tree sibling `index`). Contextual facts (search\nstate, deep-search flags, display position) are deliberately absent:\na context-dependent row id is inexpressible by construction.",
+        "doc": "A menu node before its row id is assigned — the argument to `GetRowIdFn`.\nCarries definitional facts only (`def`, `pathSegment`, `defPath`, resolved\n`parent`, `depth`, def-tree sibling `index`). Contextual facts (search\nstate, deep-search flags, display position) are deliberately absent:\na context-dependent row id is inexpressible by construction.",
         "definition": "Omit<PopupMenuNode, 'id'>",
         "props": [
           {
@@ -10439,10 +10439,10 @@
             "referencePath": "@bazza-ui/react.NodeDef"
           },
           {
-            "name": "segment",
+            "name": "pathSegment",
             "type": "string",
             "required": true,
-            "description": "This node's path component: explicit `def.id` verbatim when present,\notherwise the slugified `value` (kinds without a display value use\ntheir required `id`; id-less separators have an empty segment)."
+            "description": "This node's path component: explicit `def.id` verbatim when present,\notherwise the slugified `value` (kinds without a display value use\ntheir required `id`; id-less separators have an empty path segment)."
           },
           {
             "name": "defPath",

--- a/apps/web/content/docs/dropdown-menu/api-reference.mdx
+++ b/apps/web/content/docs/dropdown-menu/api-reference.mdx
@@ -495,7 +495,7 @@ Configuration options for deep search behavior.
 
 ### GetRowIdFn
 
-Function type for `getRowId` on `Root`. It receives the unidentified resolved node (`UnidentifiedMenuNode` — the resolved node without its `id`) and is read once at mount. The node carries only definitional facts: `def`, `kind`, `segment`, `defPath`, `parent`, `depth`, `index`, and `children` (empty at id-computation time). Render-context facts (search state, display position) are excluded by construction.
+Function type for `getRowId` on `Root`. It receives the unidentified resolved node (`UnidentifiedMenuNode` — the resolved node without its `id`) and is read once at mount. The node carries only definitional facts: `def`, `kind`, `pathSegment`, `defPath`, `parent`, `depth`, `index`, and `children` (empty at id-computation time). Render-context facts (search state, display position) are excluded by construction.
 
 ```tsx
 <DropdownMenu.Root getRowId={(node) => node.def.id ?? node.defPath.join('.')}>

--- a/packages/react/src/context-menu/root/root.tsx
+++ b/packages/react/src/context-menu/root/root.tsx
@@ -12,7 +12,7 @@ import {
   usePopupMenuRoot,
   type VirtualAnchor,
 } from '../../internal/popup-menu/index.js'
-import type { GetRowIdFn } from '../../internal/popup-menu/resolve/types.js'
+import type { GetRowIdFn } from '../../internal/popup-menu/menu-tree/types.js'
 import type {
   ContextMenuHighlightChangeEventDetails,
   ContextMenuOpenChangeEventDetails,

--- a/packages/react/src/dropdown-menu/root/root.tsx
+++ b/packages/react/src/dropdown-menu/root/root.tsx
@@ -11,7 +11,7 @@ import {
   type UsePopupMenuRootParams,
   usePopupMenuRoot,
 } from '../../internal/popup-menu/index.js'
-import type { GetRowIdFn } from '../../internal/popup-menu/resolve/types.js'
+import type { GetRowIdFn } from '../../internal/popup-menu/menu-tree/types.js'
 import type {
   DropdownMenuHighlightChangeEventDetails,
   DropdownMenuOpenChangeEventDetails,

--- a/packages/react/src/internal/popup-menu/components/providers.tsx
+++ b/packages/react/src/internal/popup-menu/components/providers.tsx
@@ -25,7 +25,7 @@ import {
   resolvePopupMenuSafeTriangleAreaDebugConfig,
 } from '../contexts/popup-menu-debug-context.js'
 import { AimGuardProvider } from '../hooks/use-aim-guard.js'
-import type { MenuTreeResolver } from '../resolve/resolver.js'
+import type { MenuTreeResolver } from '../menu-tree/resolver.js'
 import type { FocusOwnerStore } from '../store/FocusOwnerStore.js'
 import { FocusZoneRegistry } from '../store/FocusZoneRegistry.js'
 import type { OpenChainStore } from '../store/OpenChainStore.js'

--- a/packages/react/src/internal/popup-menu/components/surface/surface.tsx
+++ b/packages/react/src/internal/popup-menu/components/surface/surface.tsx
@@ -39,7 +39,7 @@ import type {
   DataSurfaceProps,
   DeepSearchConfig,
 } from '../../deep-search/types.js'
-import { isPopupMenuNode } from '../../resolve/resolve.js'
+import { isPopupMenuNode } from '../../menu-tree/resolve.js'
 import { getTabbables } from '../../utils/tabbables.js'
 
 // Surface doesn't expose data attributes - using empty state

--- a/packages/react/src/internal/popup-menu/contexts/graft-point-context.ts
+++ b/packages/react/src/internal/popup-menu/contexts/graft-point-context.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import type { PopupMenuNode } from '../resolve/types.js'
+import type { PopupMenuNode } from '../menu-tree/types.js'
 
 /** The enclosing submenu's resolved node — the graft point a nested data Surface attaches its content under. Null at the popup root and wherever the enclosing branch is not part of a resolved tree. */
 const GraftPointContext = React.createContext<PopupMenuNode | null>(null)

--- a/packages/react/src/internal/popup-menu/contexts/menu-tree-resolver-context.ts
+++ b/packages/react/src/internal/popup-menu/contexts/menu-tree-resolver-context.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import type { MenuTreeResolver } from '../resolve/resolver.js'
+import type { MenuTreeResolver } from '../menu-tree/resolver.js'
 
 const MenuTreeResolverContext = React.createContext<MenuTreeResolver | null>(
   null,

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { CommandMenu } from '../../../../command-menu/index.js'
 import type { ContextMenu } from '../../../../context-menu/index.js'
 import { DropdownMenu } from '../../../../dropdown-menu/index.js'
-import type { PopupMenuNode } from '../../resolve/types.js'
+import type { PopupMenuNode } from '../../menu-tree/types.js'
 import type {
   CheckboxItemDef,
   CheckboxItemRenderParams,

--- a/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
@@ -21,8 +21,8 @@ import {
   defaultGetRowId,
   isPopupMenuNode,
   resolveDetachedNode,
-} from '../resolve/resolve.js'
-import type { PopupMenuNode } from '../resolve/types.js'
+} from '../menu-tree/resolve.js'
+import type { PopupMenuNode } from '../menu-tree/types.js'
 import {
   type AsyncMenuState,
   useAsyncMenuCoordinator,

--- a/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
@@ -6,8 +6,8 @@ import {
   defaultGetRowId,
   isPopupMenuNode,
   resolveDetachedNode,
-} from '../resolve/resolve.js'
-import type { PopupMenuNode } from '../resolve/types.js'
+} from '../menu-tree/resolve.js'
+import type { PopupMenuNode } from '../menu-tree/types.js'
 import { useAsyncMenuCoordinator } from './async-coordinator.js'
 import { useDataPopupContext } from './context.js'
 import { warnOutOfTreeDef } from './data-list.js'

--- a/packages/react/src/internal/popup-menu/deep-search/types.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/types.ts
@@ -5,7 +5,7 @@ import type { PopupMenuRadioGroupProps } from '../components/radio-group/radio-g
 import type { PopupMenuRadioItemProps } from '../components/radio-item/radio-item.js'
 import type { PopupMenuSubmenuTriggerProps } from '../components/submenu-trigger/submenu-trigger.js'
 import type { PopupMenuSubpageTriggerProps } from '../components/subpage-trigger/subpage-trigger.js'
-import type { PopupMenuNode } from '../resolve/types.js'
+import type { PopupMenuNode } from '../menu-tree/types.js'
 
 // ============================================================================
 // Async Loader Types

--- a/packages/react/src/internal/popup-menu/deep-search/utils.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/utils.ts
@@ -1,7 +1,7 @@
 import { commandScore } from '../../listbox/utils/command-score.js'
 import { normalizeValue, slugify } from '../../listbox/utils/normalize.js'
-import { defaultGetRowId, resolveDetachedNode } from '../resolve/resolve.js'
-import type { PopupMenuNode } from '../resolve/types.js'
+import { defaultGetRowId, resolveDetachedNode } from '../menu-tree/resolve.js'
+import type { PopupMenuNode } from '../menu-tree/types.js'
 import type {
   AsyncNodesConfig,
   BreadcrumbNode,

--- a/packages/react/src/internal/popup-menu/events.ts
+++ b/packages/react/src/internal/popup-menu/events.ts
@@ -3,7 +3,7 @@ import type {
   GenericEventDetails,
   REASONS,
 } from '../../utils/events/index.js'
-import type { PopupMenuNode } from './resolve/types.js'
+import type { PopupMenuNode } from './menu-tree/types.js'
 
 // ============================================================================
 // Shared Popup Menu Event Types

--- a/packages/react/src/internal/popup-menu/hooks/use-popup-menu-root.ts
+++ b/packages/react/src/internal/popup-menu/hooks/use-popup-menu-root.ts
@@ -14,9 +14,9 @@ import type {
   PopupMenuHighlightChangeHandler,
   PopupMenuOpenChangeReason,
 } from '../events.js'
-import type { MenuTreeResolver } from '../resolve/resolver.js'
-import { createMenuTreeResolver } from '../resolve/resolver.js'
-import type { GetRowIdFn } from '../resolve/types.js'
+import type { MenuTreeResolver } from '../menu-tree/resolver.js'
+import { createMenuTreeResolver } from '../menu-tree/resolver.js'
+import type { GetRowIdFn } from '../menu-tree/types.js'
 import { FocusOwnerStore } from '../store/FocusOwnerStore.js'
 import { OpenChainStore } from '../store/OpenChainStore.js'
 

--- a/packages/react/src/internal/popup-menu/index.ts
+++ b/packages/react/src/internal/popup-menu/index.ts
@@ -362,10 +362,10 @@ export {
   isTreeItemDef,
 } from './deep-search/utils.js'
 export type { PopupMenuHighlightChangeHandler } from './events.js'
-export { defaultGetRowId, isPopupMenuNode } from './resolve/resolve.js'
-export type { MenuTreeResolver } from './resolve/resolver.js'
+export { defaultGetRowId, isPopupMenuNode } from './menu-tree/resolve.js'
+export type { MenuTreeResolver } from './menu-tree/resolver.js'
 export type {
   GetRowIdFn,
   PopupMenuNode,
   UnidentifiedMenuNode,
-} from './resolve/types.js'
+} from './menu-tree/types.js'

--- a/packages/react/src/internal/popup-menu/menu-tree/__tests__/mount.test.tsx
+++ b/packages/react/src/internal/popup-menu/menu-tree/__tests__/mount.test.tsx
@@ -111,7 +111,7 @@ describe('mounted menu-tree resolution', () => {
           onResolver={(value) => {
             resolver = value
           }}
-          getRowId={(node) => `x-${node.def.id ?? node.segment}`}
+          getRowId={(node) => `x-${node.def.id ?? node.pathSegment}`}
           content={[item('Settings'), submenu('Status', [item('Backlog')], [])]}
         />,
       )

--- a/packages/react/src/internal/popup-menu/menu-tree/__tests__/resolve.test.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/__tests__/resolve.test.ts
@@ -14,7 +14,7 @@ describe('resolveNodeDefs', () => {
     const [node] = resolveNodeDefs([item('Apple')], null, [], defaultGetRowId)
 
     expect(node).toMatchObject({
-      segment: 'apple',
+      pathSegment: 'apple',
       defPath: ['apple'],
       id: 'apple',
       depth: 0,
@@ -32,7 +32,7 @@ describe('resolveNodeDefs', () => {
     )
 
     expect(node).toMatchObject({
-      segment: 'Custom ID!',
+      pathSegment: 'Custom ID!',
       defPath: ['Custom ID!'],
       id: 'Custom ID!',
     })
@@ -64,7 +64,7 @@ describe('resolveNodeDefs', () => {
     const [node] = resolveNodeDefs([group], null, [], defaultGetRowId)
     const child = node.children[0]
 
-    expect(node).toMatchObject({ id: 'g1', segment: 'g1', defPath: ['g1'] })
+    expect(node).toMatchObject({ id: 'g1', pathSegment: 'g1', defPath: ['g1'] })
     expect(child).toMatchObject({
       defPath: ['backlog'],
       id: 'backlog',
@@ -84,7 +84,7 @@ describe('resolveNodeDefs', () => {
     const child = node.children[0]
 
     expect(node).toMatchObject({
-      segment: 'rg1',
+      pathSegment: 'rg1',
       id: 'rg1',
       defPath: ['rg1'],
     })
@@ -114,7 +114,7 @@ describe('resolveNodeDefs', () => {
       defaultGetRowId,
     )
 
-    expect(node).toMatchObject({ segment: '', defPath: [], id: '' })
+    expect(node).toMatchObject({ pathSegment: '', defPath: [], id: '' })
     expect(node.children[0]).toMatchObject({
       defPath: ['backlog'],
       id: 'backlog',
@@ -129,7 +129,7 @@ describe('resolveNodeDefs', () => {
       defaultGetRowId,
     )
 
-    expect(nodes[1]).toMatchObject({ segment: '', id: '', index: 1 })
+    expect(nodes[1]).toMatchObject({ pathSegment: '', id: '', index: 1 })
   })
 
   it('matches computeDefPath for nested contributing ancestors', () => {

--- a/packages/react/src/internal/popup-menu/menu-tree/__tests__/resolver.test.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/__tests__/resolver.test.ts
@@ -416,7 +416,7 @@ describe('getRowId seam', () => {
 
     expect(capture.node).toMatchObject({
       def: parent.children[0]!.def,
-      segment: 'backlog',
+      pathSegment: 'backlog',
       defPath: ['status', 'backlog'],
       parent,
       depth: 1,
@@ -448,7 +448,7 @@ describe('getRowId seam', () => {
     const explicitProbe = {
       def: explicit,
       kind: explicit.kind,
-      segment: 'explicit',
+      pathSegment: 'explicit',
       defPath: ['different'],
       parent: null,
       children: [],
@@ -459,7 +459,7 @@ describe('getRowId seam', () => {
     const idlessProbe = {
       def: idless,
       kind: idless.kind,
-      segment: 'ignored',
+      pathSegment: 'ignored',
       defPath: ['path', 'ignored'],
       parent: null,
       children: [],

--- a/packages/react/src/internal/popup-menu/menu-tree/resolve.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/resolve.ts
@@ -17,7 +17,7 @@ export function isPopupMenuNode(value: unknown): value is PopupMenuNode {
     value !== null &&
     'def' in value &&
     typeof (value as PopupMenuNode).id === 'string' &&
-    typeof (value as PopupMenuNode).segment === 'string' &&
+    typeof (value as PopupMenuNode).pathSegment === 'string' &&
     Array.isArray((value as PopupMenuNode).defPath) &&
     Array.isArray((value as PopupMenuNode).children) &&
     typeof (value as PopupMenuNode).depth === 'number' &&
@@ -101,7 +101,7 @@ export function resolveNodeDefs(
     const unidentified: UnidentifiedMenuNode = {
       def,
       kind: def.kind,
-      segment,
+      pathSegment: segment,
       defPath,
       parent,
       children: [],

--- a/packages/react/src/internal/popup-menu/menu-tree/resolver.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/resolver.ts
@@ -68,20 +68,20 @@ function prospectiveIdentity(
   basePath: readonly string[],
   index: number,
   getRowId: GetRowIdFn,
-): { segment: string; defPath: string[]; id: string } {
+): { pathSegment: string; defPath: string[]; id: string } {
   const segment = segmentForDef(def)
   const defPath = segment ? [...basePath, segment] : [...basePath]
   const probe: UnidentifiedMenuNode = {
     def,
     kind: def.kind,
-    segment,
+    pathSegment: segment,
     defPath,
     parent,
     children: [],
     depth: parent ? parent.depth + 1 : 0,
     index,
   }
-  return { segment, defPath, id: getRowId(probe) }
+  return { pathSegment: segment, defPath, id: getRowId(probe) }
 }
 
 export function createMenuTreeResolver(
@@ -168,7 +168,7 @@ export function createMenuTreeResolver(
 
     return defs.map((def, index) => {
       const node = matches[index]
-      const { segment, defPath, id } = prospectiveIdentity(
+      const { pathSegment, defPath, id } = prospectiveIdentity(
         def,
         parent,
         basePath,
@@ -197,7 +197,7 @@ export function createMenuTreeResolver(
 
       if (defToNode.get(node.def) === node) defToNode.delete(node.def)
       node.def = def
-      node.segment = segment
+      node.pathSegment = pathSegment
       node.defPath = defPath
       node.index = index
       if (node.id !== id) {

--- a/packages/react/src/internal/popup-menu/menu-tree/types.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/types.ts
@@ -15,9 +15,9 @@ export interface PopupMenuNode {
   /**
    * This node's path component: explicit `def.id` verbatim when present,
    * otherwise the slugified `value` (kinds without a display value use
-   * their required `id`; id-less separators have an empty segment).
+   * their required `id`; id-less separators have an empty path segment).
    */
-  segment: string
+  pathSegment: string
   /**
    * Definition path: segments from the menu root to this node, including
    * its own segment, root-first. Only submenu, subpage, and tree-item
@@ -37,7 +37,7 @@ export interface PopupMenuNode {
 
 /**
  * A menu node before its row id is assigned — the argument to `GetRowIdFn`.
- * Carries definitional facts only (`def`, `segment`, `defPath`, resolved
+ * Carries definitional facts only (`def`, `pathSegment`, `defPath`, resolved
  * `parent`, `depth`, def-tree sibling `index`). Contextual facts (search
  * state, deep-search flags, display position) are deliberately absent:
  * a context-dependent row id is inexpressible by construction.


### PR DESCRIPTION
## Summary

Two naming fixes in the resolved-node model, plus the domain-vocabulary doc: `PopupMenuNode.segment` becomes `pathSegment`, and the `resolve/` directory becomes `menu-tree/`. No code moves between files; no behavior change.

## Changes

- **`segment` → `pathSegment`** on `PopupMenuNode` (and `UnidentifiedMenuNode` via `Omit`), with JSDoc updated. The old name read as a synonym for `id` — the two are in fact equal whenever a def carries an explicit `id`, which is exactly what made it confusing. `pathSegment` says what it is: this node's own component of `defPath`.
- **`resolve/` → `menu-tree/`.** The codebase already called this a menu tree in 97 symbol occurrences (`createMenuTreeResolver` ×31, `menuTreeResolver` ×30, `MenuTreeResolver` ×21, `useMenuTreeResolver` ×9, `MenuTreeResolverContext` ×6); the directory was the sole outlier, and it also killed the `resolve/resolve.ts` stutter. Filenames inside are unchanged.
- **`CONTEXT.md` is now committed** — it had only ever existed as an untracked local file, and this stack made parts of it wrong. Corrected: `Row Id Strategy` and `Display Path` moved to a "Removed vocabulary" section (both deleted in #442), the `hybrid` reference dropped from Breadcrumbs, `Menu Tree` and `Detached Node` added, `Segment` annotated with its `pathSegment` field name, and a short module-layout header.
- Docs: the `GetRowIdFn` field list in `api-reference.mdx`; `types-meta.json` regenerated (`"segment"` → 0 occurrences, `pathSegment` → 3).
- Changeset `.changeset/path-segment-and-menu-tree.md` (`minor`, breaking-voiced).

## Motivation

Slice 1 of the naming pass ([UI-474](https://linear.app/bazzalabs/issue/UI-474/naming-pass-pathsegment-menu-tree-data-first-parent-e)), landing on top of the stack rather than amending Parent A — amending would have force-pushed 14 PRs and restacked 13 branches through a file move that collides with #443's and #446's edits to `deep-search/types.ts`. All PRs merge together, so the final `canary` state is identical either way. Builds on #449; #451 (`deep-search/` → `data-first/`) stacks on this.

**A `defs/` extraction was planned here and abandoned.** The goal was to break the type-only cycle `menu-tree/types.ts` ↔ `deep-search/types.ts`. It can't work: every def carries a render callback, render params carry `node: PopupMenuNode` (added in #443), and `PopupMenuNode.def` is a `NodeDef` — extracting the defs relocates and enlarges the loop. The cycle is now documented as accepted (both edges are `import type`, erased at compile time). The only real fixes are genericizing `PopupMenuNode<TDef>` or colocating the models; both are follow-up.

## Tests

No new tests — mechanical rename. Coverage is the gates: `bun run check` 0, `bun run type-check` 0 (incl. `apps/web`), `bun run test --filter @bazza-ui/react` → **885 tests, unchanged**, `bun run build --filter @bazza-ui/react` 0 (subpath declaration emit intact). Verified no stale paths (`grep "/resolve/"` → 0, catching two-level relative imports) and that the unrelated `segment`-named identifiers (`segmentForDef`, `getSubpagePageId`'s `breadcrumbSegments`/`leafSegment`) were left untouched.

Closes [UI-475](https://linear.app/bazzalabs/issue/UI-475/rename-segment-to-pathsegment-and-resolve-to-menu-tree)
