### PR TITLE
refactor(popup-menu)!: rename resolved identity vocabulary

### DIFF
--- a/.changeset/rename-resolved-identity-vocabulary.md
+++ b/.changeset/rename-resolved-identity-vocabulary.md
@@ -1,0 +1,21 @@
+---
+'@bazza-ui/react': minor
+---
+
+**Breaking change.** Rename popup-menu identity vocabulary and the custom resolution seam:
+
+- `getRowId` → `getResolvedId` on `DropdownMenu.Root`, `ContextMenu.Root`, and `CommandMenu.Root`.
+- `GetRowIdFn` → `GetResolvedIdFn`.
+- `UnidentifiedMenuNode` → `UnresolvedMenuNode`.
+- `PopupMenuNode.pathSegment` → `definitionKey`.
+- `PopupMenuNode.defPath` → `definitionPath`.
+- `defaultGetRowId` → `defaultGetResolvedId`.
+- `segmentForDef` → `definitionKeyForDef`.
+- `contributesPathSegment` → `contributesDefinitionPath`.
+
+Update custom callbacks and property reads to use the new names. Resolved IDs retain the current default behavior: explicit `def.id`, otherwise the dot-joined `definitionPath`.
+
+Direct migration:
+
+- `UsePopupMenuRootParams.getRowId` → `UsePopupMenuRootParams.getResolvedId`.
+- `MenuTreeResolver.getRowId` → `MenuTreeResolver.getResolvedId`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,7 +15,7 @@ A user-authored, declarative description of one menu entry (item, checkbox item,
 _Avoid_: node config, definition object
 
 **Menu Node**:
-The library-created, resolved instance of a node def — carries identity (row id, path segment, definition path), tree links (parent, children), and a reference to its originating def. Exactly one per logical row per menu root, in every render context; created by resolution at the root, or by grafting. Surfaced to consumers as `Node` under each family namespace.
+The library-created, resolved instance of a node def — carries identity (resolved ID, definition key, definition path), tree links (parent, children), and a reference to its originating def. Exactly one per logical row per menu root, in every render context; created by resolution at the root, or by grafting. Surfaced to consumers as `Node` under each family namespace.
 _Avoid_: resolved node (as a noun — "resolution" stays as the process), wrapper, instance
 
 **Menu Tree**:
@@ -26,11 +26,11 @@ _Avoid_: node graph, model
 The render-scoped wrapper the pipeline builds from node defs for one surface's current render (filtering, scoring, grouping applied). Rebuilt per render; context-dependent.
 _Avoid_: row wrapper
 
-**Segment** (field: `pathSegment`):
-A node's single path component: its explicit id verbatim when present, otherwise its slugified value. A segment is not necessarily slug-shaped (explicit ids pass through untouched); segments that resolve to empty are dropped from paths. The concept is "segment"; the field is named `pathSegment` because a bare `segment` reads as a synonym for the row id (they are in fact equal whenever a def carries an explicit id).
-_Avoid_: slug, key, part
+**Definition Key** (field: `definitionKey`):
+A node's single definition-path component: its explicit id verbatim when present, otherwise its slugified value. Keys that resolve to empty are dropped from paths.
+_Avoid_: segment, slug, part
 
-**Definition Path** (`defPath`):
+**Definition Path** (`definitionPath`):
 The segments from the menu root to a node in the definition tree, including the node's own segment. Identical wherever the node renders — browse, deep search, or recursion. The canonical identity path.
 _Avoid_: absolute path, tree path, full path, ancestor path
 
@@ -41,12 +41,15 @@ _Avoid_: trail, crumb path
 **Browse / Deep Search**:
 The two render contexts: browsing renders each surface's own nodes in place; deep search flattens a subtree into the searching surface as results. A row's identity must not depend on which context displays it.
 
-**Row Id**:
-The unique identity of a menu node — the value persistent state, registration, and highlight key off. Produced once per node by `getRowId` (default: explicit id verbatim, else the joined definition path). Definitional and context-free: a row id never depends on how or where the row is rendered. Context-dependent ids are inexpressible by construction — `getRowId` receives only definitional facts.
+**Resolved ID** (`id`):
+The unique identity of a menu node — the value persistent state, registration, and highlight key off. Produced once per node by `getResolvedId` (default: explicit `def.id` verbatim, otherwise the dot-joined `definitionPath`). This slice preserves that current dot-path behavior. Definitional and context-free: a resolved ID never depends on how or where the row is rendered. Context-dependent ids are inexpressible by construction — `getResolvedId` receives only definitional facts.
 _Avoid_: composite id, qualified id
 
+**Unresolved Menu Node** (`UnresolvedMenuNode`):
+The definitional menu-node facts passed to `getResolvedId` before the resolved ID is assigned.
+
 **Graft**:
-Resolving node defs that arrive after mount (async loader results; render-time content) and attaching the resulting nodes under an already-resolved parent — the graft point — so they join the single resolved tree with correct lineage (definition path, row id).
+Resolving node defs that arrive after mount (async loader results; render-time content) and attaching the resulting nodes under an already-resolved parent — the graft point — so they join the single resolved tree with correct lineage (definition path, Resolved ID).
 _Avoid_: merge, inject, append
 
 **Detached Node**:
@@ -57,5 +60,7 @@ _Avoid_: orphan node, temp node
 
 These terms described the string-based identity model and no longer exist in the code. They appear here only so the names are not reintroduced with new meanings.
 
-- **Row Id Strategy** (`rowIdStrategy`: `qualified` / `explicit` / `hybrid`) and `getQualifiedRowId` — superseded by the `getRowId` seam. `hybrid` has no successor: it made ids depend on render context, which the resolved-node model forbids by construction.
+- **Row Id Strategy** (`rowIdStrategy`: `qualified` / `explicit` / `hybrid`) and `getQualifiedRowId` — superseded by the `getResolvedId` seam. `hybrid` has no successor: it made ids depend on render context, which the resolved-node model forbids by construction.
+- **Row ID** / `getRowId` — replaced by Resolved ID / `getResolvedId`.
+- **Segment** / `pathSegment` — replaced by Definition Key / `definitionKey`.
 - **Display Path** (`displayPath`) — the segments of the submenus enclosing the surface a row was displayed in. Contextual by nature; deleted along with the strategy machinery that consumed it.

--- a/packages/react/src/command-menu/index.ts
+++ b/packages/react/src/command-menu/index.ts
@@ -79,7 +79,7 @@ export type {
   DisplayRowNode,
   DisplaySeparatorNode,
   DisplaySubpageNode,
-  GetRowIdFn,
+  GetResolvedIdFn,
   GroupBehavior,
   GroupDef,
   GroupRenderContext,
@@ -116,11 +116,12 @@ export type {
   SubpageDef,
   SubpageTriggerRenderParams,
   SubpageTriggerRenderProps,
-  UnidentifiedMenuNode,
+  UnresolvedMenuNode,
 } from '../internal/popup-menu/index.js'
 export {
   DataListContext,
   DataSurfaceContext,
+  defaultGetResolvedId,
   defineRadioGroup,
   isDisplayGroupNode,
   isDisplayRadioGroupNode,

--- a/packages/react/src/command-menu/root/root.tsx
+++ b/packages/react/src/command-menu/root/root.tsx
@@ -4,7 +4,7 @@ import { Dialog } from '@base-ui/react/dialog'
 import * as React from 'react'
 import type { PopupMenuOpenChangeReason } from '../../internal/popup-menu/events.js'
 import {
-  type GetRowIdFn,
+  type GetResolvedIdFn,
   PopupMenuProviders,
   type UsePopupMenuRootParams,
   usePopupMenuRoot,
@@ -22,13 +22,13 @@ export interface CommandMenuRootProps {
   modal?: boolean
   disabled?: boolean
   /**
-   * Computes canonical row ids for data-first content from the unidentified resolved node (definitional facts only).
+   * Computes canonical Resolved IDs for data-first content from the Unresolved Menu Node (definitional facts only).
    * @default explicit `def.id` verbatim, else the joined definition path
    * Read once when the menu root mounts — later changes have no effect.
    * @example
-   * <CommandMenu.Root getRowId={(node) => node.def.id ?? node.defPath.join('.')} />
+   * <CommandMenu.Root getResolvedId={(node) => node.def.id ?? node.definitionPath.join('.')} />
    */
-  getRowId?: GetRowIdFn
+  getResolvedId?: GetResolvedIdFn
 }
 
 /**
@@ -46,7 +46,7 @@ export function CommandMenuRoot(props: CommandMenuRoot.Props) {
     hotkey,
     modal = true,
     disabled,
-    getRowId,
+    getResolvedId,
   } = props
 
   const {
@@ -64,7 +64,7 @@ export function CommandMenuRoot(props: CommandMenuRoot.Props) {
     defaultOpen,
     disabled,
     closeOnOutsidePress: 'pointerdown',
-    getRowId,
+    getResolvedId,
   })
 
   store.useControlledProp('openProp', openProp)

--- a/packages/react/src/context-menu/index.ts
+++ b/packages/react/src/context-menu/index.ts
@@ -242,7 +242,7 @@ export type {
   DisplayRadioGroupNode,
   DisplayRowNode,
   DisplaySubpageNode,
-  GetRowIdFn,
+  GetResolvedIdFn,
   GroupBehavior,
   GroupDef,
   GroupLabelRenderParams,
@@ -274,11 +274,12 @@ export type {
   TreeItemDef,
   TreeItemRenderParams,
   TreeItemRenderProps,
-  UnidentifiedMenuNode,
+  UnresolvedMenuNode,
 } from '../internal/popup-menu/index.js'
 export {
   DataListContext,
   DataSurfaceContext,
+  defaultGetResolvedId,
   defineRadioGroup,
   isDisplayGroupNode,
   isDisplayRadioGroupNode,

--- a/packages/react/src/context-menu/root/root.tsx
+++ b/packages/react/src/context-menu/root/root.tsx
@@ -12,7 +12,7 @@ import {
   usePopupMenuRoot,
   type VirtualAnchor,
 } from '../../internal/popup-menu/index.js'
-import type { GetRowIdFn } from '../../internal/popup-menu/menu-tree/types.js'
+import type { GetResolvedIdFn } from '../../internal/popup-menu/menu-tree/types.js'
 import type {
   ContextMenuHighlightChangeEventDetails,
   ContextMenuOpenChangeEventDetails,
@@ -59,7 +59,7 @@ export interface ContextMenuRootProps {
   /**
    * Callback when the highlighted item changes.
    * Useful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.
-   * `id` is first. `node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.
+   * `id` is first. `node` is the resolved menu node carrying the highlighted ID, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that ID (e.g. JSX-defined rows). A JSX row that shares an ID with a data-first node yields that node; Resolved IDs are expected to be unique per menu.
    * The fourth parameter contains event details including the reason for the change.
    */
   onHighlightChange?: PopupMenuHighlightChangeHandler<ContextMenuHighlightChangeEventDetails>
@@ -105,18 +105,18 @@ export interface ContextMenuRootProps {
   actionsRef?: React.RefObject<ContextMenuRoot.Actions | null>
 
   /**
-   * - Otherwise, use the row's full definition path (`defPath`) — identical in
+   * - Otherwise, use the row's full definition path (`definitionPath`) — identical in
    *   browse and deep-search contexts
    */
 
   /**
-   * Computes canonical row ids for data-first content from the unidentified resolved node (definitional facts only).
+   * Computes canonical Resolved IDs for data-first content from the Unresolved Menu Node (definitional facts only).
    * @default explicit `def.id` verbatim, else the joined definition path
    * Read once when the menu root mounts — later changes have no effect.
    * @example
-   * <ContextMenu.Root getRowId={(node) => node.def.id ?? node.defPath.join('.')} />
+   * <ContextMenu.Root getResolvedId={(node) => node.def.id ?? node.definitionPath.join('.')} />
    */
-  getRowId?: GetRowIdFn
+  getResolvedId?: GetResolvedIdFn
 
   /**
    * Debug visualization options for submenu interaction heuristics.
@@ -196,7 +196,7 @@ export function ContextMenuRoot(props: ContextMenuRoot.Props) {
     closeOnOutsidePress = 'pointerdown',
     onOpenChangeComplete: onOpenChangeCompleteProp,
     actionsRef,
-    getRowId,
+    getResolvedId,
     debug,
     children,
   } = props
@@ -224,7 +224,7 @@ export function ContextMenuRoot(props: ContextMenuRoot.Props) {
       onHighlightChange as unknown as UsePopupMenuRootParams['onHighlightChange'],
     closeOnOutsidePress,
     disabled: disabledProp,
-    getRowId,
+    getResolvedId,
   })
 
   const popoverActionsRef = React.useRef<Popover.Root.Actions | null>(null)

--- a/packages/react/src/dropdown-menu/index.ts
+++ b/packages/react/src/dropdown-menu/index.ts
@@ -259,7 +259,7 @@ export type {
   DisplayRowNode,
   DisplaySeparatorNode,
   DisplaySubpageNode,
-  GetRowIdFn,
+  GetResolvedIdFn,
   GroupBehavior,
   GroupDef,
   GroupLabelRenderParams,
@@ -301,11 +301,12 @@ export type {
   TreeItemDef,
   TreeItemRenderParams,
   TreeItemRenderProps,
-  UnidentifiedMenuNode,
+  UnresolvedMenuNode,
 } from '../internal/popup-menu/index.js'
 export {
   DataListContext,
   DataSurfaceContext,
+  defaultGetResolvedId,
   defineRadioGroup,
   isDisplayGroupNode,
   isDisplayRadioGroupNode,

--- a/packages/react/src/dropdown-menu/root/root.tsx
+++ b/packages/react/src/dropdown-menu/root/root.tsx
@@ -11,7 +11,7 @@ import {
   type UsePopupMenuRootParams,
   usePopupMenuRoot,
 } from '../../internal/popup-menu/index.js'
-import type { GetRowIdFn } from '../../internal/popup-menu/menu-tree/types.js'
+import type { GetResolvedIdFn } from '../../internal/popup-menu/menu-tree/types.js'
 import type {
   DropdownMenuHighlightChangeEventDetails,
   DropdownMenuOpenChangeEventDetails,
@@ -81,7 +81,7 @@ export interface DropdownMenuRootProps
   /**
    * Callback when the highlighted item changes.
    * Useful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.
-   * `id` is first. `node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.
+   * `id` is first. `node` is the resolved menu node carrying the highlighted ID, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that ID (e.g. JSX-defined rows). A JSX row that shares an ID with a data-first node yields that node; Resolved IDs are expected to be unique per menu.
    * The fourth parameter contains event details including the reason for the change.
    */
   onHighlightChange?: PopupMenuHighlightChangeHandler<DropdownMenuHighlightChangeEventDetails>
@@ -110,13 +110,13 @@ export interface DropdownMenuRootProps
   actionsRef?: React.RefObject<DropdownMenuRoot.Actions | null>
 
   /**
-   * Computes canonical row ids for data-first content from the unidentified resolved node (definitional facts only).
+   * Computes canonical Resolved IDs for data-first content from the Unresolved Menu Node (definitional facts only).
    * @default explicit `def.id` verbatim, else the joined definition path
    * Read once when the menu root mounts — later changes have no effect.
    * @example
-   * <DropdownMenu.Root getRowId={(node) => node.def.id ?? node.defPath.join('.')} />
+   * <DropdownMenu.Root getResolvedId={(node) => node.def.id ?? node.definitionPath.join('.')} />
    */
-  getRowId?: GetRowIdFn
+  getResolvedId?: GetResolvedIdFn
 
   /**
    * Debug visualization options for submenu interaction heuristics.
@@ -144,7 +144,7 @@ export function DropdownMenuRoot(props: DropdownMenuRoot.Props) {
     closeOnOutsidePress = 'pointerdown',
     onOpenChangeComplete: onOpenChangeCompleteProp,
     actionsRef,
-    getRowId,
+    getResolvedId,
     debug,
     children,
     ...rest
@@ -173,7 +173,7 @@ export function DropdownMenuRoot(props: DropdownMenuRoot.Props) {
       onHighlightChange as unknown as UsePopupMenuRootParams['onHighlightChange'],
     closeOnOutsidePress,
     disabled,
-    getRowId,
+    getResolvedId,
   })
 
   const popoverActionsRef = useRef<Popover.Root.Actions | null>(null)

--- a/packages/react/src/internal/popup-menu/CONTEXT.md
+++ b/packages/react/src/internal/popup-menu/CONTEXT.md
@@ -15,7 +15,7 @@ A user-authored, declarative description of one menu entry (item, checkbox item,
 _Avoid_: node config, definition object
 
 **Menu Node**:
-The library-created, resolved instance of a node def — carries identity (row id, path segment, definition path), tree links (parent, children), and a reference to its originating def. Exactly one per logical row per menu root, in every render context; created by resolution at the root, or by grafting. Surfaced to consumers as `Node` under each family namespace.
+The library-created, resolved instance of a node def — carries identity (resolved ID, definition key, definition path), tree links (parent, children), and a reference to its originating def. Exactly one per logical row per menu root, in every render context; created by resolution at the root, or by grafting. Surfaced to consumers as `Node` under each family namespace.
 _Avoid_: resolved node (as a noun — "resolution" stays as the process), wrapper, instance
 
 **Menu Tree**:
@@ -26,11 +26,11 @@ _Avoid_: node graph, model
 The render-scoped wrapper the pipeline builds from node defs for one surface's current render (filtering, scoring, grouping applied). Rebuilt per render; context-dependent.
 _Avoid_: row wrapper
 
-**Segment** (field: `pathSegment`):
-A node's single path component: its explicit id verbatim when present, otherwise its slugified value. A segment is not necessarily slug-shaped (explicit ids pass through untouched); segments that resolve to empty are dropped from paths. The concept is "segment"; the field is named `pathSegment` because a bare `segment` reads as a synonym for the row id (they are in fact equal whenever a def carries an explicit id).
-_Avoid_: slug, key, part
+**Definition Key** (field: `definitionKey`):
+A node's single definition-path component: its explicit id verbatim when present, otherwise its slugified value. Keys that resolve to empty are dropped from paths.
+_Avoid_: segment, slug, part
 
-**Definition Path** (`defPath`):
+**Definition Path** (`definitionPath`):
 The segments from the menu root to a node in the definition tree, including the node's own segment. Identical wherever the node renders — browse, deep search, or recursion. The canonical identity path.
 _Avoid_: absolute path, tree path, full path, ancestor path
 
@@ -41,12 +41,15 @@ _Avoid_: trail, crumb path
 **Browse / Deep Search**:
 The two render contexts: browsing renders each surface's own nodes in place; deep search flattens a subtree into the searching surface as results. A row's identity must not depend on which context displays it.
 
-**Row Id**:
-The unique identity of a menu node — the value persistent state, registration, and highlight key off. Produced once per node by `getRowId` (default: explicit id verbatim, else the joined definition path). Definitional and context-free: a row id never depends on how or where the row is rendered. Context-dependent ids are inexpressible by construction — `getRowId` receives only definitional facts.
+**Resolved ID** (`id`):
+The unique identity of a menu node — the value persistent state, registration, and highlight key off. Produced once per node by `getResolvedId` (default: explicit `def.id` verbatim, otherwise the dot-joined `definitionPath`). This slice preserves that current dot-path behavior. Definitional and context-free: a resolved ID never depends on how or where the row is rendered. Context-dependent ids are inexpressible by construction — `getResolvedId` receives only definitional facts.
 _Avoid_: composite id, qualified id
 
+**Unresolved Menu Node** (`UnresolvedMenuNode`):
+The definitional menu-node facts passed to `getResolvedId` before the resolved ID is assigned.
+
 **Graft**:
-Resolving node defs that arrive after mount (async loader results; render-time content) and attaching the resulting nodes under an already-resolved parent — the graft point — so they join the single resolved tree with correct lineage (definition path, row id).
+Resolving node defs that arrive after mount (async loader results; render-time content) and attaching the resulting nodes under an already-resolved parent — the graft point — so they join the single resolved tree with correct lineage (definition path, Resolved ID).
 _Avoid_: merge, inject, append
 
 **Detached Node**:
@@ -61,5 +64,7 @@ _Avoid_: list store, selection engine
 
 These terms described the string-based identity model and no longer exist in the code. They appear here only so the names are not reintroduced with new meanings.
 
-- **Row Id Strategy** (`rowIdStrategy`: `qualified` / `explicit` / `hybrid`) and `getQualifiedRowId` — superseded by the `getRowId` seam. `hybrid` has no successor: it made ids depend on render context, which the resolved-node model forbids by construction.
+- **Row Id Strategy** (`rowIdStrategy`: `qualified` / `explicit` / `hybrid`) and `getQualifiedRowId` — superseded by the `getResolvedId` seam. `hybrid` has no successor: it made ids depend on render context, which the resolved-node model forbids by construction.
+- **Row ID** / `getRowId` — replaced by Resolved ID / `getResolvedId`.
+- **Segment** / `pathSegment` — replaced by Definition Key / `definitionKey`.
 - **Display Path** (`displayPath`) — the segments of the submenus enclosing the surface a row was displayed in. Contextual by nature; deleted along with the strategy machinery that consumed it.

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
@@ -43,8 +43,8 @@ void commandNodeDefAlias
 
 /**
  * Creates an ItemDef with a render function that includes data-testid.
- * Note: Does NOT set explicit `id` so that defaultGetQualifiedRowId generates
- * composite IDs from breadcrumbs + value during deep search.
+ * Note: Does NOT set explicit `id` so that the default Resolved ID is derived
+ * from the definition path during deep search.
  */
 function createTestItemDef(
   testId: string,
@@ -399,18 +399,18 @@ describe('useDataList', () => {
     await waitFor(() =>
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining(
-          '[PopupMenu] Duplicate row id "same" resolved for multiple rows in the same menu',
+          '[PopupMenu] Duplicate Resolved ID "same" resolved for multiple rows in the same menu',
         ),
       ),
     )
     expect(
       warn.mock.calls.filter(([message]) =>
-        String(message).startsWith('[PopupMenu] Duplicate row id'),
+        String(message).startsWith('[PopupMenu] Duplicate Resolved ID'),
       ),
     ).toHaveLength(1)
   })
 
-  it('does not warn for a clean menu with respect to duplicate row ids', async () => {
+  it('does not warn for a clean menu with respect to duplicate Resolved IDs', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     render(<MenuWithFlatItems />)
 
@@ -420,7 +420,7 @@ describe('useDataList', () => {
 
     expect(
       warn.mock.calls.some(([message]) =>
-        String(message).startsWith('[PopupMenu] Duplicate row id'),
+        String(message).startsWith('[PopupMenu] Duplicate Resolved ID'),
       ),
     ).toBe(false)
   })
@@ -751,7 +751,7 @@ function NestedSurfaceMenu({
   )
 }
 
-it('warns when nested surfaces share an explicit row id', async () => {
+it('warns when nested surfaces share an explicit Resolved ID', async () => {
   const user = userEvent.setup()
   const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -767,12 +767,12 @@ it('warns when nested surfaces share an explicit row id', async () => {
 
   expect(
     warn.mock.calls.filter(([message]) =>
-      String(message).startsWith('[PopupMenu] Duplicate row id'),
+      String(message).startsWith('[PopupMenu] Duplicate Resolved ID'),
     ),
   ).toHaveLength(1)
   expect(warn).toHaveBeenCalledWith(
     expect.stringContaining(
-      '[PopupMenu] Duplicate row id "shared-row" resolved for multiple rows in the same menu',
+      '[PopupMenu] Duplicate Resolved ID "shared-row" resolved for multiple rows in the same menu',
     ),
   )
 })
@@ -1328,7 +1328,7 @@ describe('resolved render params', () => {
     const child = createTestItemDef('path-child', 'Child', {
       render: ({ props, node }) => (
         <DropdownMenu.Item {...props} data-testid="path-child">
-          <span data-testid="child-path">{node.defPath.join('/')}</span>
+          <span data-testid="child-path">{node.definitionPath.join('/')}</span>
         </DropdownMenu.Item>
       ),
     })
@@ -1370,14 +1370,14 @@ describe('resolved render params', () => {
   })
 })
 
-describe('resolved row ids', () => {
+describe('Resolved IDs', () => {
   function ResolvedRowsMenu({
     search = false,
-    getRowId,
+    getResolvedId,
     captureSubpageParams,
   }: {
     search?: boolean
-    getRowId?: (node: { def: NodeDef; defPath: string[] }) => string
+    getResolvedId?: (node: { def: NodeDef; definitionPath: string[] }) => string
     captureSubpageParams?: (params: ItemRenderParams) => void
   }) {
     const content = React.useMemo(
@@ -1405,7 +1405,7 @@ describe('resolved row ids', () => {
     )
 
     return (
-      <DropdownMenu.Root defaultOpen getRowId={getRowId}>
+      <DropdownMenu.Root defaultOpen getResolvedId={getResolvedId}>
         <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
         <DropdownMenu.Portal>
           <DropdownMenu.Positioner>
@@ -1428,7 +1428,7 @@ describe('resolved row ids', () => {
     )
   }
 
-  it('uses definition paths for nested browse row ids', async () => {
+  it('uses definition paths for nested browse Resolved IDs', async () => {
     const user = userEvent.setup()
     render(<ResolvedRowsMenu />)
     await user.hover(screen.getByTestId('submenu-trigger-status'))
@@ -1440,7 +1440,7 @@ describe('resolved row ids', () => {
     )
   })
 
-  it('keeps nested row ids while deep-searching', async () => {
+  it('keeps nested Resolved IDs while deep-searching', async () => {
     const user = userEvent.setup()
     render(<ResolvedRowsMenu search />)
     await user.type(screen.getByRole('combobox', { name: 'Search' }), 'backlog')
@@ -1452,12 +1452,14 @@ describe('resolved row ids', () => {
     )
   })
 
-  it('uses the root getRowId seam for rendered rows', async () => {
+  it('uses the root getResolvedId seam for rendered rows', async () => {
     const user = userEvent.setup()
     render(
       <ResolvedRowsMenu
         search
-        getRowId={(node) => `x-${node.def.id ?? node.defPath.join('.')}`}
+        getResolvedId={(node) =>
+          `x-${node.def.id ?? node.definitionPath.join('.')}`
+        }
       />,
     )
     await user.type(screen.getByRole('combobox', { name: 'Search' }), 'backlog')
@@ -1466,7 +1468,7 @@ describe('resolved row ids', () => {
     )
   })
 
-  it('uses subpage-qualified ids and the root getRowId seam for subpage rows', async () => {
+  it('uses subpage-qualified ids and the root getResolvedId seam for subpage rows', async () => {
     const user = userEvent.setup()
     let subpageParams: ItemRenderParams | undefined
     const { unmount } = render(
@@ -1484,12 +1486,17 @@ describe('resolved row ids', () => {
       ),
     )
     expect(subpageParams!.node.id).toBe('details.assigned-to-me')
-    expect(subpageParams!.node.defPath).toEqual(['details', 'assigned-to-me'])
+    expect(subpageParams!.node.definitionPath).toEqual([
+      'details',
+      'assigned-to-me',
+    ])
 
     unmount()
     render(
       <ResolvedRowsMenu
-        getRowId={(node) => `x-${node.def.id ?? node.defPath.join('.')}`}
+        getResolvedId={(node) =>
+          `x-${node.def.id ?? node.definitionPath.join('.')}`
+        }
       />,
     )
     await user.click(screen.getByTestId('subpage-trigger-details'))

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/get-subpage-page-id.test.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/get-subpage-page-id.test.ts
@@ -59,7 +59,7 @@ describe('getSubpagePageId', () => {
     ).toBe('subpage.parent-value.Parent.Page.current-page')
   })
 
-  it('drops empty breadcrumb and leaf segments', () => {
+  it('drops empty breadcrumb and leaf Definition Keys', () => {
     expect(
       getSubpagePageId(subpage('', { id: '' }), [
         breadcrumb('', ''),
@@ -68,10 +68,10 @@ describe('getSubpagePageId', () => {
     ).toBe('subpage.visible-value')
   })
 
-  it('drops an empty explicit id even when the value is non-empty (canonical empty-segment rule)', () => {
-    // Per the canonical Segment rule, an explicit id is used verbatim — an
-    // empty-string id therefore resolves to an empty segment, which is
-    // dropped from the path (matching resolver defPath semantics). Consumers
+  it('drops an empty explicit id even when the value is non-empty (canonical empty Definition Key rule)', () => {
+    // Per the canonical Definition Key rule, an explicit id is used verbatim — an
+    // empty-string id therefore resolves to an empty Definition Key, which is
+    // dropped from the path (matching resolver definitionPath semantics). Consumers
     // must omit `id` (not pass '') to fall back to the slugified value.
     expect(getSubpagePageId(subpage('Settings', { id: '' }), [])).toBe(
       'subpage',

--- a/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
@@ -18,7 +18,7 @@ import { useMenuTreeResolver } from '../contexts/menu-tree-resolver-context.js'
 import { useMaybeSubpageContext } from '../contexts/subpage-context.js'
 import { useMaybeSubpageStack } from '../contexts/subpage-stack-context.js'
 import {
-  defaultGetRowId,
+  defaultGetResolvedId,
   isPopupMenuNode,
   resolveDetachedNode,
 } from '../menu-tree/resolve.js'
@@ -71,7 +71,7 @@ export function warnOutOfTreeDef(def: NodeDef): void {
   if (process.env.NODE_ENV !== 'production' && !warnedOutOfTreeDefs.has(def)) {
     warnedOutOfTreeDefs.add(def)
     console.warn(
-      "[PopupMenu] Computed a row id for a definition outside the resolved menu tree. The id falls back to a root-relative resolution. Supply the definition through the menu's content/async pipeline, or memoize definitions passed to renderNode.",
+      "[PopupMenu] Computed a Resolved ID for a definition outside the resolved menu tree. The ID falls back to a root-relative resolution. Supply the definition through the menu's content/async pipeline, or memoize definitions passed to renderNode.",
     )
   }
 }
@@ -556,8 +556,8 @@ export const DataListInner = React.forwardRef<
       const resolved = resolver?.getNodeForDef(def)
       if (resolved) return resolved
       warnOutOfTreeDef(def)
-      const getRowId = resolver?.getRowId ?? defaultGetRowId
-      return resolveDetachedNode(def, getRowId)
+      const getResolvedId = resolver?.getResolvedId ?? defaultGetResolvedId
+      return resolveDetachedNode(def, getResolvedId)
     },
     [resolver],
   )
@@ -1402,7 +1402,7 @@ export const DataListInner = React.forwardRef<
           ref={forwardedRef}
           label={label}
           {...listProps}
-          // Re-measure rows when deep-search mode toggles — the same row IDs
+          // Re-measure rows when deep-search mode toggles — the same Resolved IDs
           // render different content (label vs breadcrumb row). Consumer deps
           // are merged in rather than replaced.
           remeasureDependencies={[

--- a/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import { useMenuTreeResolver } from '../contexts/menu-tree-resolver-context.js'
 import {
-  defaultGetRowId,
+  defaultGetResolvedId,
   isPopupMenuNode,
   resolveDetachedNode,
 } from '../menu-tree/resolve.js'
@@ -230,8 +230,8 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
       const resolved = resolver?.getNodeForDef(def)
       if (resolved) return resolved
       warnOutOfTreeDef(def)
-      const getRowId = resolver?.getRowId ?? defaultGetRowId
-      return resolveDetachedNode(def, getRowId)
+      const getResolvedId = resolver?.getResolvedId ?? defaultGetResolvedId
+      return resolveDetachedNode(def, getResolvedId)
     },
     [resolver],
   )

--- a/packages/react/src/internal/popup-menu/deep-search/types.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/types.ts
@@ -366,7 +366,7 @@ export interface RowRenderContext {
  */
 export type ItemRenderProps = {
   /**
-   * Canonical resolved row id for the item (explicit `id` verbatim, else the
+   * Canonical Resolved ID for the item (explicit `id` verbatim, else the
    * definition path — identical in browse and deep search).
    * Must be passed to the rendered component for navigation to work.
    */
@@ -756,9 +756,9 @@ export interface RadioGroupLabelRenderParams {
 interface BaseNodeDef {
   /**
    * Unique identifier for this node.
-   * If provided, it is used verbatim as the resolved row id. If omitted, the
+   * If provided, it is used verbatim as the Resolved ID. If omitted, the
    * canonical id is the node's definition path (ancestor segments plus the
-   * slugified `value`), or whatever the root `getRowId` seam computes.
+   * slugified `value`), or whatever the root `getResolvedId` seam computes.
    */
   id?: string
   /** Whether this node is hidden */

--- a/packages/react/src/internal/popup-menu/deep-search/utils.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/utils.ts
@@ -1,6 +1,9 @@
 import { commandScore } from '../../listbox/utils/command-score.js'
 import { normalizeValue, slugify } from '../../listbox/utils/normalize.js'
-import { defaultGetRowId, resolveDetachedNode } from '../menu-tree/resolve.js'
+import {
+  defaultGetResolvedId,
+  resolveDetachedNode,
+} from '../menu-tree/resolve.js'
 import type { PopupMenuNode } from '../menu-tree/types.js'
 import type {
   AsyncNodesConfig,
@@ -30,9 +33,9 @@ const identityQuery = (query: string) => query
 
 // ============================================================================
 /**
- * Computes a row's canonical definition-tree path (`defPath`): the display
- * path of the computing surface, then breadcrumb segments, then the node's
- * own segment (`id`, or its slugified `value`), root-first. Empty segments
+ * Computes a row's canonical definition-tree path (`definitionPath`): the display
+ * path of the computing surface, then breadcrumb components, then the node's
+ * own Definition Key (`id`, or its slugified `value`), root-first. Empty keys
  * are skipped. Identical wherever the row renders — browse, deep search,
  * or recursion.
  */
@@ -862,7 +865,7 @@ function expandTreeNode(
 export function resolveDetachedNodeForDef<D extends NodeDef>(
   def: D,
 ): PopupMenuNode<D> {
-  return resolveDetachedNode(def, defaultGetRowId)
+  return resolveDetachedNode(def, defaultGetResolvedId)
 }
 
 export function getBrowseNodesPreserve(

--- a/packages/react/src/internal/popup-menu/hooks/use-popup-menu-root.ts
+++ b/packages/react/src/internal/popup-menu/hooks/use-popup-menu-root.ts
@@ -16,7 +16,7 @@ import type {
 } from '../events.js'
 import type { MenuTreeResolver } from '../menu-tree/resolver.js'
 import { createMenuTreeResolver } from '../menu-tree/resolver.js'
-import type { GetRowIdFn } from '../menu-tree/types.js'
+import type { GetResolvedIdFn } from '../menu-tree/types.js'
 import { FocusOwnerStore } from '../store/FocusOwnerStore.js'
 import { OpenChainStore } from '../store/OpenChainStore.js'
 
@@ -26,11 +26,11 @@ import { OpenChainStore } from '../store/OpenChainStore.js'
 
 export interface UsePopupMenuRootParams {
   /**
-   * Computes canonical row ids for data-first content from the unidentified resolved node (definitional facts only).
+   * Computes canonical Resolved IDs for data-first content from the Unresolved Menu Node (definitional facts only).
    * @default explicit `def.id` verbatim, else the joined definition path
    * Read once when the menu root mounts — later changes have no effect.
    */
-  getRowId?: GetRowIdFn
+  getResolvedId?: GetResolvedIdFn
   /**
    * Callback when the open state changes.
    * The second parameter contains event details including the reason for the change.
@@ -152,13 +152,13 @@ export function usePopupMenuRoot(
     closeOnOutsidePress = 'pointerdown',
     disabled: disabledProp = false,
     defaultDisabled = false,
-    getRowId,
+    getResolvedId,
   } = params
 
   const menuTreeResolverRef = React.useRef<MenuTreeResolver | null>(null)
   if (menuTreeResolverRef.current === null) {
     menuTreeResolverRef.current = createMenuTreeResolver(
-      getRowId ? { getRowId } : undefined,
+      getResolvedId ? { getResolvedId } : undefined,
     )
   }
   const menuTreeResolver = menuTreeResolverRef.current

--- a/packages/react/src/internal/popup-menu/index.ts
+++ b/packages/react/src/internal/popup-menu/index.ts
@@ -358,10 +358,10 @@ export {
 // Utilities
 export { isTreeItemDef } from './deep-search/utils.js'
 export type { PopupMenuHighlightChangeHandler } from './events.js'
-export { defaultGetRowId, isPopupMenuNode } from './menu-tree/resolve.js'
+export { defaultGetResolvedId, isPopupMenuNode } from './menu-tree/resolve.js'
 export type { MenuTreeResolver } from './menu-tree/resolver.js'
 export type {
-  GetRowIdFn,
+  GetResolvedIdFn,
   PopupMenuNode,
-  UnidentifiedMenuNode,
+  UnresolvedMenuNode,
 } from './menu-tree/types.js'

--- a/packages/react/src/internal/popup-menu/menu-tree/__tests__/mount.test.tsx
+++ b/packages/react/src/internal/popup-menu/menu-tree/__tests__/mount.test.tsx
@@ -5,7 +5,7 @@ import { DropdownMenu } from '../../../../dropdown-menu/index.js'
 import { useMenuTreeResolver } from '../../contexts/menu-tree-resolver-context.js'
 import type { ItemDef, NodeDef, SubmenuDef } from '../../deep-search/types.js'
 import type { MenuTreeResolver } from '../resolver.js'
-import type { GetRowIdFn } from '../types.js'
+import type { GetResolvedIdFn } from '../types.js'
 
 function item(value: string): ItemDef {
   return {
@@ -36,15 +36,15 @@ function Menu({
   content,
   onResolver,
   search = false,
-  getRowId,
+  getResolvedId,
 }: {
   content: NodeDef[]
   onResolver: (value: MenuTreeResolver) => void
   search?: boolean
-  getRowId?: GetRowIdFn
+  getResolvedId?: GetResolvedIdFn
 }) {
   return (
-    <DropdownMenu.Root defaultOpen getRowId={getRowId}>
+    <DropdownMenu.Root defaultOpen getResolvedId={getResolvedId}>
       <DropdownMenu.Trigger>Open</DropdownMenu.Trigger>
       <Probe onResolver={onResolver} />
       <DropdownMenu.Portal>
@@ -103,15 +103,15 @@ function submenu(
 }
 
 describe('mounted menu-tree resolution', () => {
-  describe('public getRowId prop', () => {
-    it('uses the custom row-id seam for resolver node ids', async () => {
+  describe('public getResolvedId prop', () => {
+    it('uses the custom Resolved ID seam for resolver node IDs', async () => {
       let resolver!: MenuTreeResolver
       render(
         <Menu
           onResolver={(value) => {
             resolver = value
           }}
-          getRowId={(node) => `x-${node.def.id ?? node.pathSegment}`}
+          getResolvedId={(node) => `x-${node.def.id ?? node.definitionKey}`}
           content={[item('Settings'), submenu('Status', [item('Backlog')], [])]}
         />,
       )
@@ -143,7 +143,7 @@ describe('mounted menu-tree resolution', () => {
       expect(resolver.getNodeById('status.backlog')).toBeDefined(),
     )
     const node = resolver.getNodeById('status.backlog')!
-    expect(node.defPath).toEqual(['status', 'backlog'])
+    expect(node.definitionPath).toEqual(['status', 'backlog'])
     expect(node.parent?.id).toBe('status')
     expect(resolver.rootNodes).toHaveLength(2)
   })
@@ -196,7 +196,10 @@ describe('mounted menu-tree resolution', () => {
     await waitFor(() => expect(resolver.getNodeById('a.extra')).toBeDefined())
     const parent = resolver.getNodeById('a')!
     expect(resolver.getNodeById('a.extra')?.parent).toBe(parent)
-    expect(resolver.getNodeById('a.extra')?.defPath).toEqual(['a', 'extra'])
+    expect(resolver.getNodeById('a.extra')?.definitionPath).toEqual([
+      'a',
+      'extra',
+    ])
     expect(parent.children.filter((node) => node.id === 'a.leaf')).toHaveLength(
       1,
     )
@@ -234,7 +237,7 @@ describe('mounted menu-tree resolution', () => {
     expect(resolver.getNodeById('a.leaf')).toBe(before)
   })
 
-  it('asserts browse pipeline wiring: the DOM reads the row ids computed by the resolver', async () => {
+  it('asserts browse pipeline wiring: the DOM reads the Resolved IDs computed by the resolver', async () => {
     render(
       <Menu
         onResolver={() => {}}
@@ -253,7 +256,7 @@ describe('mounted menu-tree resolution', () => {
     )
   })
 
-  it('asserts deep-search pipeline wiring: the DOM reads the row ids computed by the resolver', async () => {
+  it('asserts deep-search pipeline wiring: the DOM reads the Resolved IDs computed by the resolver', async () => {
     const user = userEvent.setup()
     render(
       <Menu

--- a/packages/react/src/internal/popup-menu/menu-tree/__tests__/resolve.test.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/__tests__/resolve.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { NodeDef } from '../../deep-search/types.js'
 import { computeDefPath } from '../../deep-search/utils.js'
-import { defaultGetRowId, resolveNodeDefs } from '../resolve.js'
+import { defaultGetResolvedId, resolveNodeDefs } from '../resolve.js'
 
 const item = (value: string, id?: string): NodeDef =>
   ({ kind: 'item', value, id, render: () => null }) as NodeDef
@@ -11,11 +11,16 @@ const submenu = (value: string, nodes: NodeDef[], id?: string): NodeDef =>
 
 describe('resolveNodeDefs', () => {
   it('resolves flat items', () => {
-    const [node] = resolveNodeDefs([item('Apple')], null, [], defaultGetRowId)
+    const [node] = resolveNodeDefs(
+      [item('Apple')],
+      null,
+      [],
+      defaultGetResolvedId,
+    )
 
     expect(node).toMatchObject({
-      pathSegment: 'apple',
-      defPath: ['apple'],
+      definitionKey: 'apple',
+      definitionPath: ['apple'],
       id: 'apple',
       depth: 0,
       index: 0,
@@ -28,12 +33,12 @@ describe('resolveNodeDefs', () => {
       [item('Apple', 'Custom ID!')],
       null,
       [],
-      defaultGetRowId,
+      defaultGetResolvedId,
     )
 
     expect(node).toMatchObject({
-      pathSegment: 'Custom ID!',
-      defPath: ['Custom ID!'],
+      definitionKey: 'Custom ID!',
+      definitionPath: ['Custom ID!'],
       id: 'Custom ID!',
     })
   })
@@ -43,12 +48,12 @@ describe('resolveNodeDefs', () => {
       [submenu('Status', [item('Backlog')])],
       null,
       [],
-      defaultGetRowId,
+      defaultGetResolvedId,
     )
     const child = node.children[0]
 
     expect(child).toMatchObject({
-      defPath: ['status', 'backlog'],
+      definitionPath: ['status', 'backlog'],
       id: 'status.backlog',
       parent: node,
       depth: 1,
@@ -61,62 +66,70 @@ describe('resolveNodeDefs', () => {
       id: 'g1',
       nodes: [item('Backlog')],
     } as NodeDef
-    const [node] = resolveNodeDefs([group], null, [], defaultGetRowId)
+    const [node] = resolveNodeDefs([group], null, [], defaultGetResolvedId)
     const child = node.children[0]
 
-    expect(node).toMatchObject({ id: 'g1', pathSegment: 'g1', defPath: ['g1'] })
+    expect(node).toMatchObject({
+      id: 'g1',
+      definitionKey: 'g1',
+      definitionPath: ['g1'],
+    })
     expect(child).toMatchObject({
-      defPath: ['backlog'],
+      definitionPath: ['backlog'],
       id: 'backlog',
       depth: 1,
       parent: node,
     })
   })
 
-  it('keeps radio-groups path-transparent and uses their id as segment', () => {
+  it('keeps radio-groups path-transparent and uses their id as Definition Key', () => {
     const radioGroup = {
       kind: 'radio-group',
       id: 'rg1',
       value: 'selected-value',
       nodes: [{ kind: 'radio-item', value: 'Backlog', render: () => null }],
     } as NodeDef
-    const [node] = resolveNodeDefs([radioGroup], null, [], defaultGetRowId)
+    const [node] = resolveNodeDefs([radioGroup], null, [], defaultGetResolvedId)
     const child = node.children[0]
 
     expect(node).toMatchObject({
-      pathSegment: 'rg1',
+      definitionKey: 'rg1',
       id: 'rg1',
-      defPath: ['rg1'],
+      definitionPath: ['rg1'],
     })
-    expect(child).toMatchObject({ defPath: ['backlog'], id: 'backlog' })
+    expect(child).toMatchObject({ definitionPath: ['backlog'], id: 'backlog' })
   })
 
-  it('includes tree-item segments in descendant paths', () => {
+  it('includes tree-item Definition Keys in descendant paths', () => {
     const treeItem = {
       kind: 'tree-item',
       value: 'Fruits',
       nodes: [item('Apple')],
       render: () => null,
     } as NodeDef
-    const [node] = resolveNodeDefs([treeItem], null, [], defaultGetRowId)
+    const [node] = resolveNodeDefs([treeItem], null, [], defaultGetResolvedId)
 
     expect(node.children[0]).toMatchObject({
-      defPath: ['fruits', 'apple'],
+      definitionPath: ['fruits', 'apple'],
       id: 'fruits.apple',
     })
   })
 
-  it('drops empty segments from paths', () => {
+  it('drops empty Definition Keys from paths', () => {
     const [node] = resolveNodeDefs(
       [submenu('⚙️', [item('Backlog')])],
       null,
       [],
-      defaultGetRowId,
+      defaultGetResolvedId,
     )
 
-    expect(node).toMatchObject({ pathSegment: '', defPath: [], id: '' })
+    expect(node).toMatchObject({
+      definitionKey: '',
+      definitionPath: [],
+      id: '',
+    })
     expect(node.children[0]).toMatchObject({
-      defPath: ['backlog'],
+      definitionPath: ['backlog'],
       id: 'backlog',
     })
   })
@@ -126,22 +139,22 @@ describe('resolveNodeDefs', () => {
       [item('a'), { kind: 'separator' }, item('b')] as NodeDef[],
       null,
       [],
-      defaultGetRowId,
+      defaultGetResolvedId,
     )
 
-    expect(nodes[1]).toMatchObject({ pathSegment: '', id: '', index: 1 })
+    expect(nodes[1]).toMatchObject({ definitionKey: '', id: '', index: 1 })
   })
 
   it('matches computeDefPath for nested contributing ancestors', () => {
     const root = submenu('Status', [
       submenu('Open Items', [item('Backlog')], 'open-items-id'),
     ])
-    const leaf = resolveNodeDefs([root], null, [], defaultGetRowId)[0]
+    const leaf = resolveNodeDefs([root], null, [], defaultGetResolvedId)[0]
       .children[0].children[0]
-    const ancestorSegments = ['status', 'open-items-id']
+    const ancestorDefinitionKeys = ['status', 'open-items-id']
 
-    expect(leaf.defPath).toEqual(
-      computeDefPath(ancestorSegments, [], undefined, 'Backlog'),
+    expect(leaf.definitionPath).toEqual(
+      computeDefPath(ancestorDefinitionKeys, [], undefined, 'Backlog'),
     )
   })
 })

--- a/packages/react/src/internal/popup-menu/menu-tree/__tests__/resolver.test.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/__tests__/resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { NodeDef } from '../../deep-search/types.js'
-import { defaultGetRowId, resolveNodeDefs } from '../resolve.js'
+import { defaultGetResolvedId, resolveNodeDefs } from '../resolve.js'
 import { createMenuTreeResolver } from '../resolver.js'
 
 const item = (value: string, id?: string): NodeDef =>
@@ -21,7 +21,7 @@ describe('createMenuTreeResolver', () => {
     resolver.setContent([status])
 
     expect(resolver.rootNodes).toEqual(
-      resolveNodeDefs([status], null, [], defaultGetRowId),
+      resolveNodeDefs([status], null, [], defaultGetResolvedId),
     )
     expect(resolver.getNodeById('status.backlog')?.def).toBe(backlog)
     expect(resolver.getNodeForDef(backlog)).toBe(
@@ -137,8 +137,11 @@ describe('createMenuTreeResolver', () => {
     const renamedExplicit = submenu('Workflow', [item('Backlog')], 'status-id')
     resolver.setContent([renamedExplicit])
     expect(resolver.rootNodes[0]).toBe(explicitNode)
-    expect(explicitNode.defPath).toEqual(['status-id'])
-    expect(explicitNode.children[0]!.defPath).toEqual(['status-id', 'backlog'])
+    expect(explicitNode.definitionPath).toEqual(['status-id'])
+    expect(explicitNode.children[0]!.definitionPath).toEqual([
+      'status-id',
+      'backlog',
+    ])
   })
 
   it('pairwise re-matches duplicate sibling ids', () => {
@@ -225,7 +228,7 @@ describe('createMenuTreeResolver', () => {
 
     expect(statusNode.children[0]).toBe(backlogNode)
     expect(statusNode.children[1]).toMatchObject({
-      defPath: ['status', 'in-review'],
+      definitionPath: ['status', 'in-review'],
       id: 'status.in-review',
       parent: statusNode,
       depth: statusNode.depth + 1,
@@ -273,7 +276,7 @@ describe('createMenuTreeResolver', () => {
 
     resolver.graft(groupNode, [groupNode.children[0]!.def, late])
 
-    expect(groupNode.children[1]!.defPath).toEqual(['status', 'late'])
+    expect(groupNode.children[1]!.definitionPath).toEqual(['status', 'late'])
     expect(groupNode.children[1]!.id).toBe('status.late')
   })
 })
@@ -281,7 +284,7 @@ describe('createMenuTreeResolver', () => {
 describe('duplicate detection', () => {
   const duplicateWarnings = (warn: ReturnType<typeof vi.spyOn>) =>
     warn.mock.calls.filter(([message]) =>
-      String(message).startsWith('[PopupMenu] Duplicate row id'),
+      String(message).startsWith('[PopupMenu] Duplicate Resolved ID'),
     )
 
   it('warns once for sibling id-less same-value items', () => {
@@ -372,10 +375,11 @@ describe('duplicate detection', () => {
   })
 })
 
-describe('getRowId seam', () => {
+describe('getResolvedId seam', () => {
   it('custom seam shapes ids', () => {
     const resolver = createMenuTreeResolver({
-      getRowId: (node) => node.defPath.join('/') || node.def.id || '',
+      getResolvedId: (node) =>
+        node.definitionPath.join('/') || node.def.id || '',
     })
     resolver.setContent([submenu('Status', [item('Backlog')])])
 
@@ -385,7 +389,8 @@ describe('getRowId seam', () => {
 
   it('matching agrees with the seam', () => {
     const resolver = createMenuTreeResolver({
-      getRowId: (node) => node.defPath.join('/') || node.def.id || '',
+      getResolvedId: (node) =>
+        node.definitionPath.join('/') || node.def.id || '',
     })
     resolver.setContent([submenu('Status', [item('Backlog')])])
     const statusNode = resolver.rootNodes[0]!
@@ -403,11 +408,11 @@ describe('getRowId seam', () => {
       hasId: boolean
     }> = []
     const resolver = createMenuTreeResolver({
-      getRowId: (node) => {
+      getResolvedId: (node) => {
         if (node.parent) {
           captures.push({ node: { ...node }, hasId: 'id' in node })
         }
-        return node.defPath.join('.')
+        return node.definitionPath.join('.')
       },
     })
     resolver.setContent([submenu('Status', [item('Backlog')])])
@@ -416,8 +421,8 @@ describe('getRowId seam', () => {
 
     expect(capture.node).toMatchObject({
       def: parent.children[0]!.def,
-      pathSegment: 'backlog',
-      defPath: ['status', 'backlog'],
+      definitionKey: 'backlog',
+      definitionPath: ['status', 'backlog'],
       parent,
       depth: 1,
       index: 0,
@@ -427,7 +432,7 @@ describe('getRowId seam', () => {
 
   it('index-dependent seam is stable', () => {
     const resolver = createMenuTreeResolver({
-      getRowId: (node) => `${node.defPath.join('.')}#${node.index}`,
+      getResolvedId: (node) => `${node.definitionPath.join('.')}#${node.index}`,
     })
     resolver.setContent([item('First'), item('Second')])
     const before = [...resolver.rootNodes]
@@ -448,8 +453,8 @@ describe('getRowId seam', () => {
     const explicitProbe = {
       def: explicit,
       kind: explicit.kind,
-      pathSegment: 'explicit',
-      defPath: ['different'],
+      definitionKey: 'explicit',
+      definitionPath: ['different'],
       parent: null,
       children: [],
       depth: 0,
@@ -459,19 +464,19 @@ describe('getRowId seam', () => {
     const idlessProbe = {
       def: idless,
       kind: idless.kind,
-      pathSegment: 'ignored',
-      defPath: ['path', 'ignored'],
+      definitionKey: 'ignored',
+      definitionPath: ['path', 'ignored'],
       parent: null,
       children: [],
       depth: 0,
       index: 0,
     }
 
-    expect(defaultGetRowId(explicitProbe)).toBe(
-      explicit.id ?? explicitProbe.defPath.join('.'),
+    expect(defaultGetResolvedId(explicitProbe)).toBe(
+      explicit.id ?? explicitProbe.definitionPath.join('.'),
     )
-    expect(defaultGetRowId(idlessProbe)).toBe(
-      idless.id ?? idlessProbe.defPath.join('.'),
+    expect(defaultGetResolvedId(idlessProbe)).toBe(
+      idless.id ?? idlessProbe.definitionPath.join('.'),
     )
   })
 })

--- a/packages/react/src/internal/popup-menu/menu-tree/resolve.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/resolve.ts
@@ -1,13 +1,13 @@
 import { slugify } from '../../listbox/utils/normalize.js'
 import type { NodeDef } from '../deep-search/types.js'
 import type {
-  GetRowIdFn,
+  GetResolvedIdFn,
   PopupMenuNode,
-  UnidentifiedMenuNode,
+  UnresolvedMenuNode,
 } from './types.js'
 
 const detachedNodeCache = new WeakMap<
-  GetRowIdFn,
+  GetResolvedIdFn,
   WeakMap<NodeDef, PopupMenuNode>
 >()
 
@@ -17,8 +17,8 @@ export function isPopupMenuNode(value: unknown): value is PopupMenuNode {
     value !== null &&
     'def' in value &&
     typeof (value as PopupMenuNode).id === 'string' &&
-    typeof (value as PopupMenuNode).pathSegment === 'string' &&
-    Array.isArray((value as PopupMenuNode).defPath) &&
+    typeof (value as PopupMenuNode).definitionKey === 'string' &&
+    Array.isArray((value as PopupMenuNode).definitionPath) &&
     Array.isArray((value as PopupMenuNode).children) &&
     typeof (value as PopupMenuNode).depth === 'number' &&
     'parent' in value
@@ -28,29 +28,29 @@ export function isPopupMenuNode(value: unknown): value is PopupMenuNode {
 /** Resolve a single out-of-tree def to a stable detached node (per seam, per def). */
 export function resolveDetachedNode<D extends NodeDef>(
   def: D,
-  getRowId: GetRowIdFn,
+  getResolvedId: GetResolvedIdFn,
 ): PopupMenuNode<D> {
-  let perSeam = detachedNodeCache.get(getRowId)
+  let perSeam = detachedNodeCache.get(getResolvedId)
   if (!perSeam) {
     perSeam = new WeakMap()
-    detachedNodeCache.set(getRowId, perSeam)
+    detachedNodeCache.set(getResolvedId, perSeam)
   }
   let node = perSeam.get(def)
   if (!node) {
-    node = resolveNodeDefs([def], null, [], getRowId)[0]!
+    node = resolveNodeDefs([def], null, [], getResolvedId)[0]!
     perSeam.set(def, node)
   }
   // node was built from (or cached under) this exact def; def === node.def
   return node as PopupMenuNode<D>
 }
 
-/** Default row id: explicit `def.id` verbatim, else the joined definition path. */
-export function defaultGetRowId(node: UnidentifiedMenuNode): string {
-  return node.def.id ?? node.defPath.join('.')
+/** Default Resolved ID: explicit `def.id` verbatim, else the joined definition path. */
+export function defaultGetResolvedId(node: UnresolvedMenuNode): string {
+  return node.def.id ?? node.definitionPath.join('.')
 }
 
-/** Segment for a def: explicit `id` verbatim, else slugified `value`. */
-export function segmentForDef(def: NodeDef): string {
+/** Definition Key for a def: explicit `id` verbatim, else slugified `value`. */
+export function definitionKeyForDef(def: NodeDef): string {
   switch (def.kind) {
     case 'group':
     case 'radio-group':
@@ -77,8 +77,8 @@ export function childDefsOf(def: NodeDef): readonly NodeDef[] {
   }
 }
 
-/** Kinds whose segment is part of their descendants' definition paths. */
-export function contributesPathSegment(def: NodeDef): boolean {
+/** Kinds whose Definition Key is part of their descendants' definition paths. */
+export function contributesDefinitionPath(def: NodeDef): boolean {
   return (
     def.kind === 'submenu' || def.kind === 'subpage' || def.kind === 'tree-item'
   )
@@ -87,23 +87,25 @@ export function contributesPathSegment(def: NodeDef): boolean {
 /**
  * Resolve a def list into node instances under `parent`.
  * `basePath` is the path segments contributed by ancestors (the parent's
- * `defPath` when the parent contributes a segment, otherwise the parent's
+ * `definitionPath` when the parent contributes a segment, otherwise the parent's
  * own base path); pass `[]` for roots.
  */
 export function resolveNodeDefs(
   defs: readonly NodeDef[],
   parent: PopupMenuNode | null,
   basePath: readonly string[],
-  getRowId: GetRowIdFn,
+  getResolvedId: GetResolvedIdFn,
 ): PopupMenuNode[] {
   return defs.map((def, index) => {
-    const segment = segmentForDef(def)
-    const defPath = segment ? [...basePath, segment] : [...basePath]
-    const unidentified: UnidentifiedMenuNode = {
+    const definitionKey = definitionKeyForDef(def)
+    const definitionPath = definitionKey
+      ? [...basePath, definitionKey]
+      : [...basePath]
+    const unresolved: UnresolvedMenuNode = {
       def,
       kind: def.kind,
-      pathSegment: segment,
-      defPath,
+      definitionKey,
+      definitionPath,
       parent,
       children: [],
       depth: parent ? parent.depth + 1 : 0,
@@ -112,13 +114,13 @@ export function resolveNodeDefs(
     // Call the seam before spreading so the node reflects any reads the seam
     // performs on the final definitional facts (spread-then-call would copy
     // the fields before the seam runs).
-    const id = getRowId(unidentified)
-    const node: PopupMenuNode = { ...unidentified, id }
+    const id = getResolvedId(unresolved)
+    const node: PopupMenuNode = { ...unresolved, id }
     node.children = resolveNodeDefs(
       childDefsOf(def),
       node,
-      contributesPathSegment(def) ? node.defPath : basePath,
-      getRowId,
+      contributesDefinitionPath(def) ? node.definitionPath : basePath,
+      getResolvedId,
     )
     return node
   })

--- a/packages/react/src/internal/popup-menu/menu-tree/resolver.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/resolver.ts
@@ -1,15 +1,15 @@
 import type { NodeDef } from '../deep-search/types.js'
 import {
   childDefsOf,
-  contributesPathSegment,
-  defaultGetRowId,
+  contributesDefinitionPath,
+  defaultGetResolvedId,
+  definitionKeyForDef,
   resolveNodeDefs,
-  segmentForDef,
 } from './resolve.js'
 import type {
-  GetRowIdFn,
+  GetResolvedIdFn,
   PopupMenuNode,
-  UnidentifiedMenuNode,
+  UnresolvedMenuNode,
 } from './types.js'
 
 /**
@@ -39,8 +39,8 @@ const ROW_KINDS: ReadonlySet<NodeDef['kind']> = new Set<RowKind>([
  * identical arguments are no-ops.
  */
 export interface MenuTreeResolver {
-  /** The row-id seam this resolver was created with. */
-  readonly getRowId: GetRowIdFn
+  /** The Resolved ID seam this resolver was created with. */
+  readonly getResolvedId: GetResolvedIdFn
   /** Current root nodes, in def order. */
   readonly rootNodes: readonly PopupMenuNode[]
   /** Re-supply the root def list and reconcile the whole tree. */
@@ -58,8 +58,8 @@ export interface MenuTreeResolver {
 }
 
 export interface MenuTreeResolverOptions {
-  /** Row-id seam; defaults to `defaultGetRowId`. */
-  getRowId?: GetRowIdFn
+  /** Resolved-ID seam; defaults to `defaultGetResolvedId`. */
+  getResolvedId?: GetResolvedIdFn
 }
 
 function prospectiveIdentity(
@@ -67,27 +67,29 @@ function prospectiveIdentity(
   parent: PopupMenuNode | null,
   basePath: readonly string[],
   index: number,
-  getRowId: GetRowIdFn,
-): { pathSegment: string; defPath: string[]; id: string } {
-  const segment = segmentForDef(def)
-  const defPath = segment ? [...basePath, segment] : [...basePath]
-  const probe: UnidentifiedMenuNode = {
+  getResolvedId: GetResolvedIdFn,
+): { definitionKey: string; definitionPath: string[]; id: string } {
+  const definitionKey = definitionKeyForDef(def)
+  const definitionPath = definitionKey
+    ? [...basePath, definitionKey]
+    : [...basePath]
+  const probe: UnresolvedMenuNode = {
     def,
     kind: def.kind,
-    pathSegment: segment,
-    defPath,
+    definitionKey,
+    definitionPath,
     parent,
     children: [],
     depth: parent ? parent.depth + 1 : 0,
     index,
   }
-  return { pathSegment: segment, defPath, id: getRowId(probe) }
+  return { definitionKey, definitionPath, id: getResolvedId(probe) }
 }
 
 export function createMenuTreeResolver(
   options: MenuTreeResolverOptions = {},
 ): MenuTreeResolver {
-  const getRowId = options.getRowId ?? defaultGetRowId
+  const getResolvedId = options.getResolvedId ?? defaultGetResolvedId
   let rootNodes: PopupMenuNode[] = []
   let lastRootDefs: readonly NodeDef[] | null = null
   const defToNode = new Map<NodeDef, PopupMenuNode>()
@@ -104,7 +106,7 @@ export function createMenuTreeResolver(
     if (warnedDuplicateIds.has(node.id)) return
     warnedDuplicateIds.add(node.id)
     console.warn(
-      `[PopupMenu] Duplicate row id "${node.id}" resolved for multiple rows in the same menu. Row ids must be unique for stable highlight, keyboard navigation, and persistent row state. Give the rows distinct explicit \`id\`s or distinct \`value\`s.`,
+      `[PopupMenu] Duplicate Resolved ID "${node.id}" resolved for multiple rows in the same menu. Resolved IDs must be unique for stable highlight, keyboard navigation, and persistent row state. Give the rows distinct explicit \`id\`s or distinct \`value\`s.`,
     )
   }
 
@@ -127,8 +129,8 @@ export function createMenuTreeResolver(
     left.every((part, index) => part === right[index])
 
   const baseOf = (node: PopupMenuNode): readonly string[] =>
-    contributesPathSegment(node.def)
-      ? node.defPath
+    contributesDefinitionPath(node.def)
+      ? node.definitionPath
       : node.parent
         ? baseOf(node.parent)
         : []
@@ -149,7 +151,13 @@ export function createMenuTreeResolver(
     const matches: Array<PopupMenuNode | undefined> = []
     const matched = new Set<PopupMenuNode>()
     for (const [index, def] of defs.entries()) {
-      const { id } = prospectiveIdentity(def, parent, basePath, index, getRowId)
+      const { id } = prospectiveIdentity(
+        def,
+        parent,
+        basePath,
+        index,
+        getResolvedId,
+      )
       const bucket = buckets.get(id)
       // Kind participates in matching (not just id): a kind mismatch must
       // not consume the candidate, so a later same-kind def can still match.
@@ -168,37 +176,42 @@ export function createMenuTreeResolver(
 
     return defs.map((def, index) => {
       const node = matches[index]
-      const { pathSegment, defPath, id } = prospectiveIdentity(
+      const { definitionKey, definitionPath, id } = prospectiveIdentity(
         def,
         parent,
         basePath,
         index,
-        getRowId,
+        getResolvedId,
       )
 
       if (!node) {
-        const created = resolveNodeDefs([def], parent, basePath, getRowId)[0]!
+        const created = resolveNodeDefs(
+          [def],
+          parent,
+          basePath,
+          getResolvedId,
+        )[0]!
         created.index = index
         created.id = prospectiveIdentity(
           def,
           parent,
           basePath,
           index,
-          getRowId,
+          getResolvedId,
         ).id
         register(created)
         return created
       }
 
-      if (node.def === def && samePath(node.defPath, defPath)) {
+      if (node.def === def && samePath(node.definitionPath, definitionPath)) {
         node.index = index
         return node
       }
 
       if (defToNode.get(node.def) === node) defToNode.delete(node.def)
       node.def = def
-      node.pathSegment = pathSegment
-      node.defPath = defPath
+      node.definitionKey = definitionKey
+      node.definitionPath = definitionPath
       node.index = index
       if (node.id !== id) {
         if (idToNode.get(node.id) === node) idToNode.delete(node.id)
@@ -213,14 +226,14 @@ export function createMenuTreeResolver(
         node.children,
         childDefsOf(def),
         node,
-        contributesPathSegment(def) ? node.defPath : basePath,
+        contributesDefinitionPath(def) ? node.definitionPath : basePath,
       )
       return node
     })
   }
 
   return {
-    getRowId,
+    getResolvedId,
     get rootNodes() {
       return rootNodes
     },

--- a/packages/react/src/internal/popup-menu/menu-tree/types.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/types.ts
@@ -3,7 +3,7 @@ import type { NodeDef } from '../deep-search/types.js'
 /**
  * A menu node: the library-created, resolved instance of a node def.
  * Exactly one per logical row per menu root, in every render context —
- * object identity is row identity, and `id` is its serialization.
+ * object identity is Resolved ID identity, and `id` is its serialization.
  * Created by resolution at the root or by grafting; instances are stable
  * across content re-supplies (reconciliation swaps `def` in place).
  * The type parameter narrows `def`/`kind` for callers that know the def kind
@@ -20,17 +20,17 @@ export interface PopupMenuNode<D extends NodeDef = NodeDef> {
   /**
    * This node's path component: explicit `def.id` verbatim when present,
    * otherwise the slugified `value` (kinds without a display value use
-   * their required `id`; id-less separators have an empty path segment).
+   * their required `id`; id-less separators have an empty Definition Key).
    */
-  pathSegment: string
+  definitionKey: string
   /**
-   * Definition path: segments from the menu root to this node, including
-   * its own segment, root-first. Only submenu, subpage, and tree-item
-   * ancestors contribute segments (groups and radio-groups are
-   * path-transparent). Empty segments are dropped.
+   * Definition Path: Definition Keys from the menu root to this node,
+   * including its own key, root-first. Only submenu, subpage, and tree-item
+   * ancestors contribute keys (groups and radio-groups are path-transparent).
+   * Empty keys are dropped.
    */
-  defPath: string[]
-  /** Row id: `def.id` verbatim when present, else `defPath.join('.')`. */
+  definitionPath: string[]
+  /** Resolved ID: `def.id` verbatim when present, else `definitionPath.join('.')`. */
   id: string
   parent: PopupMenuNode | null
   children: PopupMenuNode[]
@@ -41,16 +41,16 @@ export interface PopupMenuNode<D extends NodeDef = NodeDef> {
 }
 
 /**
- * A menu node before its row id is assigned — the argument to `GetRowIdFn`.
- * Carries definitional facts only (`def`, `pathSegment`, `defPath`, resolved
+ * A menu node before its resolved ID is assigned — the argument to `GetResolvedIdFn`.
+ * Carries definitional facts only (`def`, `definitionKey`, `definitionPath`, resolved
  * `parent`, `depth`, def-tree sibling `index`). Contextual facts (search
  * state, deep-search flags, display position) are deliberately absent:
- * a context-dependent row id is inexpressible by construction.
+ * a context-dependent Resolved ID is inexpressible by construction.
  */
-export type UnidentifiedMenuNode = Omit<PopupMenuNode, 'id'>
+export type UnresolvedMenuNode = Omit<PopupMenuNode, 'id'>
 
 /**
- * Computes a node's row id from definitional facts. The id must be unique
+ * Computes a node's Resolved ID from definitional facts. The ID must be unique
  * per menu root; it is the identity persistent state, registration, and
  * highlight key off.
  *
@@ -61,4 +61,4 @@ export type UnidentifiedMenuNode = Omit<PopupMenuNode, 'id'>
  * ancestor reordering, so ancestor-index-dependent ids would go stale. The
  * seam must also not mutate its argument.
  */
-export type GetRowIdFn = (node: UnidentifiedMenuNode) => string
+export type GetResolvedIdFn = (node: UnresolvedMenuNode) => string


### PR DESCRIPTION
## Summary

Renames the popup-menu identity model around Definition Keys, Definition Paths, and Resolved IDs without changing how IDs are computed.

## Changes

- Renames `pathSegment`/`defPath` and the unresolved-node types to `definitionKey`/`definitionPath` and `UnresolvedMenuNode`.
- Renames the `getRowId` seam, default helper, resolver property, and public family props/exports to Resolved ID vocabulary.
- Updates tests and `CONTEXT.md` while preserving every existing ID expectation.
- Adds a breaking-change migration note for `@bazza-ui/react`.

## Motivation

This establishes one precise identity vocabulary before the next PR adds menu- and surface-scoped default resolution. Keeping this slice behavior-neutral makes the semantic changes in the rest of the stack independently reviewable.

## Tests

- `bun run check`
- `bun run type-check`
- `bun run test --filter @bazza-ui/react` (40 files, 888 tests)
- `bun run build --filter @bazza-ui/react`

Closes [UI-489](https://linear.app/bazzalabs/issue/UI-489/rename-popup-menu-identity-vocabulary)
