### PR TITLE
refactor(popup-menu)!: require Menu Nodes in render callbacks

### DIFF
--- a/.changeset/resolved-render-node-callbacks.md
+++ b/.changeset/resolved-render-node-callbacks.md
@@ -1,0 +1,11 @@
+---
+'@bazza-ui/react': minor
+---
+
+Require resolver-owned Menu Nodes in submenu and subpage render callbacks.
+
+Migration:
+
+- Change authored property reads from `child.value` to `child.def.value`.
+- Pass resolved callback children directly to `renderNode` and `DataSurface.content` instead of passing raw definitions.
+- Callback `nodes` is a snapshot selected at invocation time, not a live collection; `asyncContent` remains the loader configuration.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,11 @@ _Avoid_: node config, definition object
 The library-created, resolved instance of a node def — carries identity (resolved ID, definition key, definition path), tree links (parent, children), and a reference to its originating def. Exactly one per logical row per menu root, in every render context; created by resolution at the root, or by grafting. Surfaced to consumers as `Node` under each family namespace.
 _Avoid_: resolved node (as a noun — "resolution" stays as the process), wrapper, instance
 
+Submenu and subpage render callbacks receive only resolver-owned child Menu Nodes.
+Their `nodes` value is a callback-time snapshot of the child definitions selected
+by the renderer, not a live collection; authored fields are available through
+`child.def`. Pass those Menu Nodes to `renderNode` and `DataSurface.content`.
+
 **Menu Tree**:
 The single resolved node tree owned by one menu root, and the `MenuTreeResolver` that maintains it. Created once per root; re-supplied content reconciles into it rather than rebuilding it.
 _Avoid_: node graph, model
@@ -51,10 +56,6 @@ The definitional menu-node facts passed to `getResolvedId` before the resolved I
 **Graft**:
 Resolving node defs that arrive after mount (async loader results; render-time content) and attaching the resulting nodes under an already-resolved parent — the graft point — so they join the single resolved tree with correct lineage (definition path, Resolved ID).
 _Avoid_: merge, inject, append
-
-**Detached Node**:
-The stable placeholder node produced for a def that is rendered but is not part of the resolved tree (a consumer passing an arbitrary def to `renderNode`). Dev-warned once per def; its id is root-relative rather than path-qualified. Not a supported authoring pattern — memoize defs and prefer explicit ids.
-_Avoid_: orphan node, temp node
 
 ## Removed vocabulary
 

--- a/packages/react/src/command-menu/command-menu-async.test.tsx
+++ b/packages/react/src/command-menu/command-menu-async.test.tsx
@@ -3,11 +3,21 @@ import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { describe, expect, it } from 'vitest'
 import {
+  PopupMenuList,
+  PopupMenuPopup,
+  PopupMenuPortal,
+  PopupMenuPositioner,
+  PopupMenuSubmenuRoot,
+  PopupMenuSubmenuTrigger,
+  PopupMenuSurface,
+} from '../internal/popup-menu/index.js'
+import {
   type AsyncLoaderResult,
   CommandMenu,
   type DeepSearchConfig,
   type LoaderComponentProps,
   type NodeDef,
+  type SubmenuDef,
   type SubpageDef,
   useDataList,
 } from './index.js'
@@ -164,23 +174,24 @@ function createItemDef(testId: string, value: string): NodeDef {
 function createSubpageDef({
   id,
   value,
-  nodes = [],
+  nodes,
   asyncNodes,
 }: {
   id: string
   value: string
   nodes?: NodeDef[]
-  asyncNodes: NonNullable<SubpageDef['asyncNodes']>
+  asyncNodes?: NonNullable<SubpageDef['asyncNodes']>
 }): SubpageDef {
   return {
     kind: 'subpage',
     id,
     value,
-    nodes,
-    asyncNodes,
+    ...(nodes ? { nodes } : {}),
+    ...(asyncNodes ? { asyncNodes } : {}),
     renderTrigger: ({ props }) => (
       <CommandMenu.SubpageTrigger
         {...props}
+        data-target-page-id={props.targetPageId}
         data-testid={`subpage-trigger-${id}`}
       >
         {value}
@@ -192,6 +203,7 @@ function createSubpageDef({
           <CommandMenu.Surface
             asyncContent={asyncContent}
             content={childNodes}
+            data-page-id={pageId}
             data-testid={`surface-${id}`}
           >
             <CommandMenu.Input
@@ -221,8 +233,16 @@ function createSubpageDef({
   }
 }
 
-function DataRows() {
+function DataRows({
+  onNode,
+}: {
+  onNode?: (
+    node: ReturnType<typeof useDataList>['nodes'][number]['node'],
+  ) => void
+}) {
   const { nodes, renderNode } = useDataList()
+
+  if (onNode && nodes[0]) onNode(nodes[0].node)
 
   return <>{nodes.map(renderNode)}</>
 }
@@ -291,6 +311,315 @@ async function resolveLoader(loader: ControllableLoader, nodes: NodeDef[]) {
 }
 
 describe('CommandMenu async data-first API', () => {
+  it('grafts async subpage branches before submenu callbacks receive static children', async () => {
+    const user = userEvent.setup()
+    const loader = createControllableLoader()
+    const child = createItemDef('static-child', 'Static child')
+    let callbackId: string | undefined
+    let callbackDef: NodeDef | undefined
+    let nestedNode:
+      | ReturnType<typeof useDataList>['nodes'][number]['node']
+      | undefined
+    const captureNestedNode = (
+      node: ReturnType<typeof useDataList>['nodes'][number]['node'],
+    ) => {
+      nestedNode = node
+    }
+    const asyncSubmenu: SubmenuDef = {
+      kind: 'submenu',
+      id: 'async-submenu',
+      value: 'Async submenu',
+      nodes: [child],
+      render: ({ props, nodes: childNodes, renderNode }) => {
+        callbackId = childNodes[0]?.id
+        callbackDef = childNodes[0]?.def
+        return (
+          <PopupMenuSubmenuRoot>
+            <PopupMenuSubmenuTrigger {...props} data-testid="async-submenu">
+              {props.id}
+            </PopupMenuSubmenuTrigger>
+            <PopupMenuPortal>
+              <PopupMenuPositioner>
+                <PopupMenuPopup>
+                  <PopupMenuSurface content={childNodes}>
+                    <PopupMenuList data-testid="async-submenu-list">
+                      <DataRows onNode={captureNestedNode} />
+                      {childNodes.map(renderNode)}
+                    </PopupMenuList>
+                  </PopupMenuSurface>
+                </PopupMenuPopup>
+              </PopupMenuPositioner>
+            </PopupMenuPortal>
+          </PopupMenuSubmenuRoot>
+        )
+      },
+    }
+    const nodes: NodeDef[] = [
+      createSubpageDef({
+        id: 'async-projects',
+        value: 'Async projects',
+        asyncNodes: {
+          type: 'static',
+          Loader: loader.Loader,
+          loadStrategy: 'lazy',
+        },
+      }),
+    ]
+
+    render(
+      <DataCommandMenu
+        deepSearch={{ enabled: true, minLength: 999 }}
+        nodes={nodes}
+      />,
+    )
+    await waitForRootInputFocus()
+    await waitForSubpageContentReady('async-projects')
+    await user.click(screen.getByTestId('subpage-trigger-async-projects'))
+    if (!screen.queryByTestId('input-async-projects')) {
+      await user.click(screen.getByTestId('subpage-trigger-async-projects'))
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId('input-async-projects')).toBeInTheDocument()
+    })
+    await resolveLoader(loader, [asyncSubmenu])
+
+    await waitFor(() => {
+      expect(callbackId).toBe('async-projects/async-submenu/static-child')
+    })
+    await user.hover(screen.getByTestId('async-submenu'))
+    await waitFor(() => expect(nestedNode?.def).toBe(child))
+    expect(callbackDef).toBe(child)
+    expect(nestedNode?.def).toBe(child)
+    expect(nestedNode?.parent?.def).toBe(asyncSubmenu)
+    expect(nestedNode?.definitionPath).toEqual([
+      'async-projects',
+      'async-submenu',
+      'static-child',
+    ])
+    expect(nestedNode?.id).toBe('async-projects/async-submenu/static-child')
+    expect(screen.getAllByTestId('item-static-child')).toHaveLength(2)
+  })
+
+  it('grafts an async-only nested subpage while its outer page is active', async () => {
+    const user = userEvent.setup()
+    const loader = createControllableLoader()
+    const nested = createSubpageDef({
+      id: 'nested',
+      value: 'Nested',
+      nodes: [createItemDef('nested-content', 'Nested content')],
+    })
+
+    render(
+      <DataCommandMenu
+        deepSearch={{ enabled: true, minLength: 999 }}
+        nodes={[
+          createSubpageDef({
+            id: 'outer',
+            value: 'Outer',
+            asyncNodes: {
+              type: 'static',
+              Loader: loader.Loader,
+              loadStrategy: 'lazy',
+            },
+          }),
+        ]}
+      />,
+    )
+
+    await waitForRootInputFocus()
+    await waitForSubpageContentReady('outer')
+    await user.click(screen.getByTestId('subpage-trigger-outer'))
+    await waitForSubpageInputFocus('outer')
+    await resolveLoader(loader, [nested])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('subpage-trigger-nested')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('subpage-trigger-nested')).toHaveAttribute(
+      'data-target-page-id',
+      'subpage.outer.nested',
+    )
+    await waitForSubpageContentReady('nested')
+    await user.click(screen.getByTestId('subpage-trigger-nested'))
+
+    await waitForSubpageContentReady('nested')
+    expect(screen.getByTestId('item-nested-content')).toBeInTheDocument()
+  })
+
+  it('grafts consecutive async subpage changes without remounting the active list', async () => {
+    const user = userEvent.setup()
+    const loader = createControllableLoader()
+    const first = createSubpageDef({
+      id: 'first-nested',
+      value: 'First nested',
+      nodes: [createItemDef('first-nested-content', 'First nested content')],
+    })
+    const second = createSubpageDef({
+      id: 'second-nested',
+      value: 'Second nested',
+      nodes: [createItemDef('second-nested-content', 'Second nested content')],
+    })
+
+    render(
+      <DataCommandMenu
+        deepSearch={{ enabled: true, minLength: 999 }}
+        nodes={[
+          createSubpageDef({
+            id: 'changing-outer',
+            value: 'Changing outer',
+            asyncNodes: {
+              type: 'static',
+              Loader: loader.Loader,
+              loadStrategy: 'lazy',
+            },
+          }),
+        ]}
+      />,
+    )
+
+    await waitForRootInputFocus()
+    await waitForSubpageContentReady('changing-outer')
+    await user.click(screen.getByTestId('subpage-trigger-changing-outer'))
+    await waitForSubpageInputFocus('changing-outer')
+    const list = screen.getByTestId('list-changing-outer')
+
+    await resolveLoader(loader, [first])
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('subpage-trigger-first-nested'),
+      ).toBeInTheDocument()
+    })
+
+    await resolveLoader(loader, [second])
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('subpage-trigger-second-nested'),
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('subpage-trigger-second-nested')).toHaveAttribute(
+      'data-target-page-id',
+      'subpage.changing-outer.second-nested',
+    )
+    await waitForSubpageContentReady('second-nested')
+    expect(screen.getByTestId('list-changing-outer')).toBe(list)
+
+    await user.click(screen.getByTestId('subpage-trigger-second-nested'))
+    await waitForSubpageContentReady('second-nested')
+    expect(screen.getByTestId('item-second-nested-content')).toBeInTheDocument()
+  })
+
+  it('publishes subpages nested inside an async submenu popup', async () => {
+    const user = userEvent.setup()
+    const loader = createControllableLoader()
+    const nested = createSubpageDef({
+      id: 'popup-nested',
+      value: 'Popup nested',
+      nodes: [createItemDef('popup-nested-content', 'Popup nested content')],
+    })
+    let callbackResult: React.ReactNode
+    const submenu: SubmenuDef = {
+      kind: 'submenu',
+      id: 'loaded-submenu',
+      value: 'Loaded submenu',
+      nodes: [nested],
+      render: ({ props, nodes: childNodes, renderNode }) => {
+        callbackResult = renderNode(childNodes[0])
+
+        return (
+          <PopupMenuSubmenuRoot>
+            <PopupMenuSubmenuTrigger {...props} data-testid="loaded-submenu">
+              Loaded submenu
+            </PopupMenuSubmenuTrigger>
+            <PopupMenuPortal>
+              <PopupMenuPositioner>
+                <PopupMenuPopup>
+                  <PopupMenuSurface content={childNodes}>
+                    <PopupMenuList data-testid="loaded-submenu-list">
+                      <DataRows />
+                    </PopupMenuList>
+                  </PopupMenuSurface>
+                </PopupMenuPopup>
+              </PopupMenuPositioner>
+            </PopupMenuPortal>
+          </PopupMenuSubmenuRoot>
+        )
+      },
+    }
+
+    render(
+      <DataCommandMenu
+        deepSearch={{ enabled: true, minLength: 999 }}
+        nodes={[
+          createSubpageDef({
+            id: 'submenu-outer',
+            value: 'Submenu outer',
+            asyncNodes: {
+              type: 'static',
+              Loader: loader.Loader,
+              loadStrategy: 'lazy',
+            },
+          }),
+        ]}
+      />,
+    )
+
+    await waitForRootInputFocus()
+    await waitForSubpageContentReady('submenu-outer')
+    await user.click(screen.getByTestId('subpage-trigger-submenu-outer'))
+    await waitForSubpageInputFocus('submenu-outer')
+    await resolveLoader(loader, [submenu])
+    await user.hover(screen.getByTestId('loaded-submenu'))
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('subpage-trigger-popup-nested'),
+      ).toBeInTheDocument()
+    })
+    expect(callbackResult).toBeTruthy()
+    await waitForSubpageContentReady('popup-nested')
+    expect(screen.getByTestId('subpage-trigger-popup-nested')).toHaveAttribute(
+      'data-target-page-id',
+      'subpage.popup-nested',
+    )
+    await user.click(screen.getByTestId('subpage-trigger-popup-nested'))
+    await waitForSubpageContentReady('popup-nested')
+    expect(screen.getByTestId('item-popup-nested-content')).toBeInTheDocument()
+  })
+
+  it('merges static and async subpage children without invalidating static content', async () => {
+    const user = userEvent.setup()
+    const loader = createControllableLoader()
+
+    render(
+      <DataCommandMenu
+        deepSearch={{ enabled: true, minLength: 999 }}
+        nodes={[
+          createSubpageDef({
+            id: 'merged',
+            value: 'Merged',
+            nodes: [createItemDef('static-merged', 'Static merged')],
+            asyncNodes: {
+              type: 'static',
+              Loader: loader.Loader,
+              loadStrategy: 'lazy',
+            },
+          }),
+        ]}
+      />,
+    )
+
+    await waitForRootInputFocus()
+    await waitForSubpageContentReady('merged')
+    await user.click(screen.getByTestId('subpage-trigger-merged'))
+    await waitForSubpageInputFocus('merged')
+    await resolveLoader(loader, [createItemDef('async-merged', 'Async merged')])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('item-static-merged')).toBeInTheDocument()
+      expect(screen.getByTestId('item-async-merged')).toBeInTheDocument()
+    })
+  })
+
   it('lazy-loads static async subpage content and suppresses Empty while loading', async () => {
     const user = userEvent.setup()
     const loader = createControllableLoader()

--- a/packages/react/src/command-menu/command-menu-data.test.tsx
+++ b/packages/react/src/command-menu/command-menu-data.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 import { describe, expect, it, vi } from 'vitest'
+import { useDataPopupContext } from '../internal/popup-menu/deep-search/context.js'
 import {
   type CheckboxItemDef,
   CommandMenu,
@@ -155,6 +156,99 @@ function DataCommandMenu({
       </CommandMenu.Portal>
     </CommandMenu.Root>
   )
+}
+
+function PublicationProbe() {
+  const { resolvedNodes } = useDataPopupContext()
+
+  return (
+    <output data-testid="publication">
+      {resolvedNodes
+        ?.map((node) => `${node.id}:${node.def.value ?? node.def.kind}`)
+        .join('|')}
+    </output>
+  )
+}
+
+function PublicationLifecycleMenu({ strict = false }: { strict?: boolean }) {
+  const [showRootSurface, setShowRootSurface] = React.useState(true)
+  const [showRootList, setShowRootList] = React.useState(true)
+  const [surfaceVersion, setSurfaceVersion] = React.useState('root')
+  const [itemValue, setItemValue] = React.useState('initial')
+  const nodes: NodeDef[] = [
+    createItemDef('published', itemValue),
+    createSubpageDef('details', 'Details', [createItemDef('child', 'Child')]),
+  ]
+
+  const menu = (
+    <CommandMenu.Root defaultOpen>
+      <CommandMenu.Trigger data-testid="trigger">Open</CommandMenu.Trigger>
+      <CommandMenu.Portal>
+        <CommandMenu.Popup>
+          <PublicationProbe />
+          <button
+            data-testid="remove-root-list"
+            onClick={() => setShowRootList(false)}
+            type="button"
+          >
+            Remove root list
+          </button>
+          <button
+            data-testid="remove-root-surface"
+            onClick={() => setShowRootSurface(false)}
+            type="button"
+          >
+            Remove root surface
+          </button>
+          <button
+            data-testid="replace-no-list"
+            onClick={() => setSurfaceVersion('replacement-no-list')}
+            type="button"
+          >
+            Replace with no-list surface
+          </button>
+          <button
+            data-testid="update-definition"
+            onClick={() => setItemValue('latest')}
+            type="button"
+          >
+            Update definition
+          </button>
+          <button
+            data-testid="replace-publishing-surface"
+            onClick={() => {
+              setSurfaceVersion('replacement-publishing')
+              setItemValue('replacement')
+            }}
+            type="button"
+          >
+            Replace publishing surface
+          </button>
+          {showRootSurface ? (
+            <CommandMenu.Surface
+              key={surfaceVersion}
+              content={nodes}
+              data-testid="surface-root"
+            >
+              <CommandMenu.Input
+                aria-label="Search commands"
+                data-testid="input-root"
+              />
+              {surfaceVersion ===
+              'replacement-no-list' ? null : showRootList ? (
+                <CommandMenu.List>
+                  <DataRows />
+                </CommandMenu.List>
+              ) : null}
+              <CommandMenu.Empty>No commands found</CommandMenu.Empty>
+            </CommandMenu.Surface>
+          ) : null}
+        </CommandMenu.Popup>
+      </CommandMenu.Portal>
+    </CommandMenu.Root>
+  )
+
+  return strict ? <React.StrictMode>{menu}</React.StrictMode> : menu
 }
 
 async function waitForRootInputFocus() {
@@ -325,5 +419,128 @@ describe('CommandMenu data-first API', () => {
       'true',
     )
     expect(screen.getByTestId('dialog')).toBeInTheDocument()
+  })
+
+  it('withdraws the root publication when its mounted root List is removed', async () => {
+    const user = userEvent.setup()
+
+    render(<PublicationLifecycleMenu />)
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(
+        'initial:initial',
+      ),
+    )
+
+    await user.click(screen.getByTestId('remove-root-list'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(''),
+    )
+  })
+
+  it('retains an active sibling publication until a subpage return with no List remount', async () => {
+    const user = userEvent.setup()
+
+    render(<PublicationLifecycleMenu />)
+    await waitForRootInputFocus()
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(
+        'initial:initial',
+      ),
+    )
+    await user.click(screen.getByTestId('subpage-trigger-details'))
+    await waitForSubpageInputFocus('details')
+
+    await user.click(screen.getByTestId('remove-root-list'))
+    expect(screen.getByTestId('publication')).toHaveTextContent(
+      'initial:initial',
+    )
+
+    await user.click(screen.getByTestId('subpage-back-details'))
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(''),
+    )
+  })
+
+  it('keeps publication through ordinary subpage navigation and List remount', async () => {
+    const user = userEvent.setup()
+
+    render(<PublicationLifecycleMenu />)
+    await waitForRootInputFocus()
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(
+        'initial:initial',
+      ),
+    )
+    await user.click(screen.getByTestId('subpage-trigger-details'))
+    await waitForSubpageInputFocus('details')
+    expect(screen.getByTestId('publication')).toHaveTextContent(
+      'initial:initial',
+    )
+
+    await user.click(screen.getByTestId('subpage-back-details'))
+    await waitForRootInputFocus()
+    expect(screen.getByTestId('publication')).toHaveTextContent(
+      'initial:initial',
+    )
+  })
+
+  it('clears publication when the registered root Surface is removed on a subpage', async () => {
+    const user = userEvent.setup()
+
+    render(<PublicationLifecycleMenu />)
+    await waitForRootInputFocus()
+    await user.click(screen.getByTestId('subpage-trigger-details'))
+    await waitForSubpageInputFocus('details')
+
+    await user.click(screen.getByTestId('remove-root-surface'))
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(''),
+    )
+  })
+
+  it('clears an old publication when a keyed root Surface without a List replaces it', async () => {
+    const user = userEvent.setup()
+
+    render(<PublicationLifecycleMenu />)
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(
+        'initial:initial',
+      ),
+    )
+
+    await user.click(screen.getByTestId('replace-no-list'))
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(''),
+    )
+  })
+
+  it('survives StrictMode effect replay, definition updates, and keyed replacement', async () => {
+    const user = userEvent.setup()
+
+    render(<PublicationLifecycleMenu strict />)
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(
+        'initial:initial',
+      ),
+    )
+
+    await user.click(screen.getByTestId('update-definition'))
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(
+        'latest:latest',
+      ),
+    )
+
+    await user.click(screen.getByTestId('replace-publishing-surface'))
+    await waitFor(() =>
+      expect(screen.getByTestId('publication')).toHaveTextContent(
+        'replacement:replacement',
+      ),
+    )
+    await new Promise((resolve) => queueMicrotask(resolve))
+    expect(screen.getByTestId('publication')).toHaveTextContent(
+      'replacement:replacement',
+    )
   })
 })

--- a/packages/react/src/command-menu/popup/popup.tsx
+++ b/packages/react/src/command-menu/popup/popup.tsx
@@ -7,9 +7,9 @@ import { SubpageStackContext } from '../../internal/popup-menu/contexts/subpage-
 import {
   DataPopupContext,
   type DataSurfaceContextValue,
+  useResolvedNodesPublication,
 } from '../../internal/popup-menu/deep-search/context.js'
 import { DataSubpagesContent } from '../../internal/popup-menu/deep-search/data-subpages.js'
-import type { NodeDef } from '../../internal/popup-menu/deep-search/types.js'
 import { useSubpageStackState } from '../../internal/popup-menu/hooks/use-subpage-stack-state.js'
 import { usePopupMenuContext } from '../../internal/popup-menu/index.js'
 import type { ComponentRenderFn } from '../../utils/types.js'
@@ -76,9 +76,10 @@ export const CommandMenuPopup = React.forwardRef<
 
   const [dataSurfaceContext, setDataSurfaceContext] =
     React.useState<DataSurfaceContextValue | null>(null)
-  const [resolvedContent, setResolvedContent] = React.useState<
-    NodeDef[] | null
-  >(null)
+  const publication = useResolvedNodesPublication(
+    dataSurfaceContext,
+    hasOpenSubpage,
+  )
 
   const toPopupState = React.useCallback(
     (baseState: Dialog.Popup.State): CommandMenuPopupState => ({
@@ -113,10 +114,9 @@ export const CommandMenuPopup = React.forwardRef<
     () => ({
       dataSurfaceContext,
       setDataSurfaceContext,
-      resolvedContent,
-      setResolvedContent,
+      ...publication,
     }),
-    [dataSurfaceContext, resolvedContent],
+    [dataSurfaceContext, publication],
   )
 
   return (

--- a/packages/react/src/internal/popup-menu/components/popup/popup.tsx
+++ b/packages/react/src/internal/popup-menu/components/popup/popup.tsx
@@ -18,9 +18,9 @@ import { SubpageStackContext } from '../../contexts/subpage-stack-context.js'
 import {
   DataPopupContext,
   type DataSurfaceContextValue,
+  useResolvedNodesPublication,
 } from '../../deep-search/context.js'
 import { DataSubpagesContent } from '../../deep-search/data-subpages.js'
-import type { NodeDef } from '../../deep-search/types.js'
 import { useAimGuard } from '../../hooks/use-aim-guard.js'
 import { useSubpageStackState } from '../../hooks/use-subpage-stack-state.js'
 import { PopupMenuPopupDataAttributes } from './popup.data-attrs.js'
@@ -130,9 +130,10 @@ export const PopupMenuPopup = React.forwardRef<
 
   const [dataSurfaceContext, setDataSurfaceContext] =
     React.useState<DataSurfaceContextValue | null>(null)
-  const [resolvedContent, setResolvedContent] = React.useState<
-    NodeDef[] | null
-  >(null)
+  const publication = useResolvedNodesPublication(
+    dataSurfaceContext,
+    hasOpenSubpage,
+  )
   const activeSurfaceId = subpageStackContextValue.activeSurfaceId
 
   // Track when popup opened to ignore initial pointer events
@@ -340,10 +341,9 @@ export const PopupMenuPopup = React.forwardRef<
     () => ({
       dataSurfaceContext,
       setDataSurfaceContext,
-      resolvedContent,
-      setResolvedContent,
+      ...publication,
     }),
-    [dataSurfaceContext, resolvedContent],
+    [dataSurfaceContext, publication],
   )
 
   return (

--- a/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/__tests__/data-list.test.tsx
@@ -19,8 +19,11 @@ import type {
   RadioItemDef,
   SubmenuDef,
   SubmenuRenderParams,
+  SubpageContentRenderParams,
   SubpageDef,
+  TreeItemDef,
 } from '../types.js'
+import { selectResolvedChildren } from '../utils.js'
 
 const resolvedNodeForFamilyAliases = {} as PopupMenuNode
 const nodeDefForFamilyAliases = {} as NodeDef
@@ -30,12 +33,39 @@ const contextNodeAlias: ContextMenu.Node = resolvedNodeForFamilyAliases
 const contextNodeDefAlias: ContextMenu.NodeDef = nodeDefForFamilyAliases
 const commandNodeAlias: CommandMenu.Node = resolvedNodeForFamilyAliases
 const commandNodeDefAlias: CommandMenu.NodeDef = nodeDefForFamilyAliases
+const acceptsSubmenuNode = (params: SubmenuRenderParams) => {
+  const node: PopupMenuNode = resolvedNodeForFamilyAliases
+  return params.renderNode(node)
+}
+const acceptsSubpageNode = (params: SubpageContentRenderParams) => {
+  const node: PopupMenuNode = resolvedNodeForFamilyAliases
+  return params.renderNode(node)
+}
 void dropdownNodeAlias
 void dropdownNodeDefAlias
 void contextNodeAlias
 void contextNodeDefAlias
 void commandNodeAlias
 void commandNodeDefAlias
+void acceptsSubmenuNode
+void acceptsSubpageNode
+
+function resolvedTestNode(
+  def: NodeDef,
+  parent: PopupMenuNode | null,
+): PopupMenuNode {
+  return {
+    def,
+    kind: def.kind,
+    definitionKey: def.id ?? def.value ?? def.kind,
+    definitionPath: [],
+    id: `${parent?.id ?? 'root'}/${def.id ?? def.value ?? def.kind}`,
+    parent,
+    children: [],
+    depth: (parent?.depth ?? -1) + 1,
+    index: parent?.children.length ?? 0,
+  } as PopupMenuNode
+}
 
 // ============================================================================
 // Test Helpers
@@ -82,7 +112,7 @@ function createTestSubmenuDef(
     id,
     value,
     nodes,
-    render: ({ props, context, renderNode }) => (
+    render: ({ props, context, nodes: childNodes, renderNode }) => (
       <DropdownMenu.Submenu>
         <DropdownMenu.SubmenuTrigger
           {...props}
@@ -95,7 +125,9 @@ function createTestSubmenuDef(
           <DropdownMenu.Positioner>
             <DropdownMenu.Popup>
               <DropdownMenu.Surface>
-                <DropdownMenu.List>{nodes.map(renderNode)}</DropdownMenu.List>
+                <DropdownMenu.List>
+                  {childNodes.map(renderNode)}
+                </DropdownMenu.List>
               </DropdownMenu.Surface>
             </DropdownMenu.Popup>
           </DropdownMenu.Positioner>
@@ -1319,7 +1351,7 @@ describe('resolved render params', () => {
     )
   })
 
-  it('passes definition paths and unwraps resolved renderNode arguments', async () => {
+  it('passes definition paths and resolver-owned renderNode arguments', async () => {
     const child = createTestItemDef('path-child', 'Child', {
       render: ({ props, node }) => (
         <DropdownMenu.Item {...props} data-testid="path-child">
@@ -1337,7 +1369,6 @@ describe('resolved render params', () => {
                 <DropdownMenu.Surface>
                   <DropdownMenu.List>
                     {renderNode(node.children[0])}
-                    {renderNode(node.children[0].def)}
                   </DropdownMenu.List>
                 </DropdownMenu.Surface>
               </DropdownMenu.Popup>
@@ -1351,17 +1382,215 @@ describe('resolved render params', () => {
     await user.hover(screen.getByRole('menuitem'))
     await waitFor(() => {
       const childRows = screen.getAllByTestId('path-child')
-      expect(childRows).toHaveLength(2)
-      expect(childRows.map((row) => row.id)).toEqual([
-        'parent/child',
-        'parent/child',
-      ])
+      expect(childRows).toHaveLength(1)
+      expect(childRows.map((row) => row.id)).toEqual(['parent/child'])
       expect(
         childRows.map(
           (row) => row.querySelector('[data-testid="child-path"]')?.textContent,
         ),
-      ).toEqual(['parent/child', 'parent/child'])
+      ).toEqual(['parent/child'])
     })
+  })
+})
+
+describe('parent-local resolved child snapshots', () => {
+  it('rerenders data-first subpage callbacks with the latest resolved definitions', async () => {
+    const renderCalls: Array<{
+      node: PopupMenuNode
+      childNodes: PopupMenuNode[]
+    }> = []
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const makeContent = (suffix: string): NodeDef[] => {
+      const child = createTestItemDef(`fresh-child-${suffix}`, 'Fresh', {
+        id: 'fresh-child',
+      })
+      const subpage: SubpageDef = {
+        kind: 'subpage',
+        id: 'fresh-parent',
+        value: 'Fresh parent',
+        nodes: [child],
+        renderTrigger: ({ props }) => (
+          <DropdownMenu.SubpageTrigger {...props}>
+            Fresh parent
+          </DropdownMenu.SubpageTrigger>
+        ),
+        renderContent: ({ node, nodes: childNodes, pageId, renderNode }) => {
+          renderCalls.push({ node, childNodes })
+          return (
+            <DropdownMenu.Subpage pageId={pageId}>
+              <DropdownMenu.Surface>
+                <DropdownMenu.List>
+                  {childNodes.map(renderNode)}
+                </DropdownMenu.List>
+              </DropdownMenu.Surface>
+            </DropdownMenu.Subpage>
+          )
+        },
+      }
+      return [subpage]
+    }
+
+    const first = makeContent('first')
+    const { rerender } = render(<MenuWithDataContent content={first} />)
+    await waitFor(() => expect(renderCalls.length).toBeGreaterThan(0))
+    const firstCall = renderCalls[renderCalls.length - 1]!
+    const firstParent = firstCall.node
+    const firstChild = firstCall.childNodes[0]!
+
+    const latest = makeContent('latest')
+    rerender(<MenuWithDataContent content={latest} />)
+    await waitFor(() => {
+      const call = renderCalls[renderCalls.length - 1]!
+      expect(call.node.def).toBe(latest[0])
+      expect(call.node).toBe(firstParent)
+      expect(call.childNodes[0]).toBe(firstChild)
+      expect(call.childNodes.map((child) => child.def)).toEqual(
+        latest[0]!.nodes,
+      )
+      expect(call.childNodes.every((child) => child.parent === call.node)).toBe(
+        true,
+      )
+      expect(
+        call.childNodes.some((child) => child.def === first[0]!.nodes[0]),
+      ).toBe(false)
+    })
+    expect(warning).not.toHaveBeenCalledWith(
+      expect.stringContaining('detached'),
+    )
+    warning.mockRestore()
+  })
+
+  it('preserves distinct shared children under two rendered submenu parents', async () => {
+    const shared = createTestItemDef('shared', 'Shared')
+    const captures: Array<{ parent: PopupMenuNode; child: PopupMenuNode }> = []
+    const makeParent = (id: string) =>
+      createTestSubmenuDef(id, id, [shared], {
+        render: ({ props, node, nodes, renderNode }) => {
+          captures.push({ parent: node, child: nodes[0]! })
+          return (
+            <DropdownMenu.Submenu>
+              <DropdownMenu.SubmenuTrigger {...props}>
+                {id}
+              </DropdownMenu.SubmenuTrigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Positioner>
+                  <DropdownMenu.Popup>
+                    <DropdownMenu.Surface>
+                      <DropdownMenu.List>
+                        {nodes.map(renderNode)}
+                      </DropdownMenu.List>
+                    </DropdownMenu.Surface>
+                  </DropdownMenu.Popup>
+                </DropdownMenu.Positioner>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Submenu>
+          )
+        },
+      })
+
+    render(
+      <MenuWithDataContent
+        content={[makeParent('first'), makeParent('second')]}
+      />,
+    )
+    await waitFor(() => expect(captures).toHaveLength(2))
+
+    expect(captures[0]!.child).not.toBe(captures[1]!.child)
+    expect(captures[0]!.child.parent).toBe(captures[0]!.parent)
+    expect(captures[1]!.child.parent).toBe(captures[1]!.parent)
+    expect(captures[0]!.child.def).toBe(shared)
+    expect(captures[1]!.child.def).toBe(shared)
+    expect(captures[0]!.child.definitionPath).toEqual(['first', 'shared'])
+    expect(captures[1]!.child.definitionPath).toEqual(['second', 'shared'])
+    expect(captures[0]!.child.id).toBe('first/shared')
+    expect(captures[1]!.child.id).toBe('second/shared')
+  })
+
+  it('rejects ambiguous graft-only and missing selected occurrences', () => {
+    const shared = createTestItemDef('shared', 'Shared')
+    const parent = resolvedTestNode(
+      createTestSubmenuDef('parent', 'Parent', []),
+      null,
+    )
+    const selected = resolvedTestNode(shared, parent)
+    const graftOnly = resolvedTestNode(shared, parent)
+    parent.children = [selected, graftOnly]
+
+    expect(() => selectResolvedChildren(parent, [shared])).toThrow(
+      'cannot be matched unambiguously',
+    )
+    parent.children = []
+    expect(() => selectResolvedChildren(parent, [shared])).toThrow(
+      'cannot be matched unambiguously',
+    )
+  })
+
+  it('filters loose radio and tree rows from a rendered submenu callback', async () => {
+    const radioRender = vi.fn(() => null)
+    const treeRender = vi.fn(() => null)
+    const itemRender = vi.fn(({ props }: ItemRenderParams) => (
+      <DropdownMenu.Item {...props} data-testid="supported-item">
+        Item
+      </DropdownMenu.Item>
+    ))
+    const checkboxRender = vi.fn(({ props }: CheckboxItemRenderParams) => (
+      <DropdownMenu.CheckboxItem {...props} data-testid="supported-checkbox">
+        Checkbox
+      </DropdownMenu.CheckboxItem>
+    ))
+    const radio: RadioItemDef = {
+      kind: 'radio-item',
+      id: 'loose-radio',
+      value: 'Radio',
+      render: radioRender,
+    }
+    const tree: TreeItemDef = {
+      kind: 'tree-item',
+      id: 'loose-tree',
+      value: 'Tree',
+      render: treeRender,
+    }
+    const nestedSubmenu = createTestSubmenuDef('nested', 'Nested', [], {
+      render: ({ props }) => (
+        <DropdownMenu.Submenu>
+          <DropdownMenu.SubmenuTrigger
+            {...props}
+            data-testid="supported-submenu"
+          >
+            Nested
+          </DropdownMenu.SubmenuTrigger>
+        </DropdownMenu.Submenu>
+      ),
+    })
+    const nestedSubpage = createTestSubpageDef('nested-page', 'Page', [])
+    const parent = createTestSubmenuDef('filter-parent', 'Parent', [
+      radio,
+      tree,
+      { kind: 'item', id: 'supported-item', value: 'Item', render: itemRender },
+      {
+        kind: 'checkbox-item',
+        id: 'supported-checkbox',
+        value: 'Checkbox',
+        render: checkboxRender,
+      },
+      nestedSubmenu,
+      nestedSubpage,
+    ])
+
+    const user = userEvent.setup()
+    render(<MenuWithDataContent content={[parent]} />)
+    await user.hover(screen.getByRole('menuitem'))
+    await waitFor(() =>
+      expect(screen.getByTestId('supported-item')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('supported-checkbox')).toBeInTheDocument()
+    expect(screen.getByTestId('supported-submenu')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('subpage-trigger-nested-page'),
+    ).toBeInTheDocument()
+    expect(radioRender).not.toHaveBeenCalled()
+    expect(treeRender).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/react/src/internal/popup-menu/deep-search/context.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/context.ts
@@ -8,6 +8,7 @@ import type {
   DisplayNode,
   IncludeInDeepSearch,
   NodeDef,
+  ResolvedMenuNode,
 } from './types.js'
 
 // ============================================================================
@@ -45,9 +46,13 @@ export interface DataPopupContextValue {
   setDataSurfaceContext: React.Dispatch<
     React.SetStateAction<DataSurfaceContextValue | null>
   >
-  /** The root data surface's async-merged content tree — the exact def references fed to the resolver; null until the root list registers. */
-  resolvedContent: NodeDef[] | null
-  setResolvedContent: React.Dispatch<React.SetStateAction<NodeDef[] | null>>
+  /** The latest callback-time snapshot of the local surface's resolver-owned roots. */
+  resolvedNodes: readonly ResolvedMenuNode[] | null
+  publishResolvedNodes: (
+    sourceId: string,
+    nodes: readonly ResolvedMenuNode[],
+  ) => () => void
+  invalidateResolvedNodes: () => void
 }
 
 export const DataPopupContext =
@@ -77,6 +82,84 @@ export function useDataPopupContext(): DataPopupContextValue {
 
 export function useMaybeDataPopupContext(): DataPopupContextValue | null {
   return React.useContext(DataPopupContext)
+}
+
+export function useResolvedNodesPublication(
+  dataSurfaceContext: DataSurfaceContextValue | null,
+  hasOpenSubpage: boolean,
+): Pick<
+  DataPopupContextValue,
+  'resolvedNodes' | 'publishResolvedNodes' | 'invalidateResolvedNodes'
+> {
+  const [publication, setPublication] = React.useState<{
+    token: symbol
+    sourceId: string
+    nodes: readonly ResolvedMenuNode[]
+    pending: boolean
+  } | null>(null)
+  const publicationRef = React.useRef(publication)
+  const registeredSourceRef = React.useRef<string | null>(null)
+  const hasOpenSubpageRef = React.useRef(hasOpenSubpage)
+  hasOpenSubpageRef.current = hasOpenSubpage
+  publicationRef.current = publication
+
+  const setCurrent = React.useCallback((next: typeof publication) => {
+    publicationRef.current = next
+    setPublication(next)
+  }, [])
+  const clearToken = React.useCallback(
+    (token: symbol) => {
+      if (publicationRef.current?.token !== token) return
+      setCurrent(null)
+    },
+    [setCurrent],
+  )
+  const publishResolvedNodes = React.useCallback(
+    (sourceId: string, nodes: readonly ResolvedMenuNode[]) => {
+      const token = Symbol('resolved-nodes-publication')
+      setCurrent({ token, sourceId, nodes: [...nodes], pending: false })
+      return () => {
+        const current = publicationRef.current
+        if (!current || current.token !== token) return
+        if (hasOpenSubpageRef.current) {
+          setCurrent({ ...current, pending: true })
+          return
+        }
+        queueMicrotask(() => clearToken(token))
+      }
+    },
+    [clearToken, setCurrent],
+  )
+  const invalidateResolvedNodes = React.useCallback(() => {
+    const current = publicationRef.current
+    if (current) setCurrent({ ...current, nodes: [...current.nodes] })
+  }, [setCurrent])
+
+  React.useEffect(() => {
+    const previous = registeredSourceRef.current
+    const next = dataSurfaceContext?.listId ?? null
+    registeredSourceRef.current = next
+    if (previous && previous !== next) {
+      const current = publicationRef.current
+      if (current?.sourceId === previous) setCurrent(null)
+    }
+  }, [dataSurfaceContext?.listId, setCurrent])
+
+  React.useEffect(() => {
+    if (hasOpenSubpage) return
+    const pending = publicationRef.current
+    if (!pending?.pending) return
+    queueMicrotask(() => clearToken(pending.token))
+  }, [clearToken, hasOpenSubpage])
+
+  return React.useMemo(
+    () => ({
+      resolvedNodes: publication?.nodes ?? null,
+      publishResolvedNodes,
+      invalidateResolvedNodes,
+    }),
+    [publication?.nodes, publishResolvedNodes, invalidateResolvedNodes],
+  )
 }
 
 // ============================================================================

--- a/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-list.tsx
@@ -1,10 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import {
-  useListboxContext,
-  type useSurfaceContext,
-} from '../../listbox/index.js'
+import type { useSurfaceContext } from '../../listbox/index.js'
 import { PopupMenuGroupLabel } from '../components/group-label/group-label.js'
 import {
   PopupMenuListPrimitive,
@@ -19,7 +16,6 @@ import { useMaybeSubpageContext } from '../contexts/subpage-context.js'
 import { useMaybeSubpageStack } from '../contexts/subpage-stack-context.js'
 import {
   defaultGetResolvedId,
-  isPopupMenuNode,
   resolveDetachedNode,
 } from '../menu-tree/resolve.js'
 import type { PopupMenuNode } from '../menu-tree/types.js'
@@ -37,15 +33,16 @@ import type {
   AsyncLoaderResult,
   AsyncNodesConfig,
   BreadcrumbNode,
-  CheckboxItemDef,
   DataListChildrenState,
   DisplayNode,
   DisplayRowNode,
   GroupRenderContext,
-  ItemDef,
   NodeDef,
   QueryDependentLoaderConfig,
   RadioGroupDef,
+  ResolvedMenuNode,
+  ResolvedMenuNodeOf,
+  RowNodeDef,
   RowRenderContext,
   SubmenuDef,
   SubpageDef,
@@ -62,19 +59,9 @@ import {
   getAsyncLoaderIdForBranch,
   getSubpagePageId,
   mergeAsyncNodesIntoTree,
+  selectResolvedChildren,
   shouldLoadEagerly,
 } from './utils.js'
-
-const warnedOutOfTreeDefs = new WeakSet<NodeDef>()
-
-export function warnOutOfTreeDef(def: NodeDef): void {
-  if (process.env.NODE_ENV !== 'production' && !warnedOutOfTreeDefs.has(def)) {
-    warnedOutOfTreeDefs.add(def)
-    console.warn(
-      "[PopupMenu] Computed a Resolved ID for a definition outside the resolved menu tree. The ID falls back to a root-relative resolution. Supply the definition through the menu's content/async pipeline, or memoize definitions passed to renderNode.",
-    )
-  }
-}
 
 function renderGroupLabelElement<
   C extends GroupRenderContext & { label?: string },
@@ -179,7 +166,102 @@ function getDisplayNodeStreamKey(displayNode: DisplayNode): string {
   return `row:${displayNode.node.def.kind}:${displayNode.node.def.id ?? ''}:${displayNode.node.def.value}:${getBreadcrumbStreamKey(displayNode.context.breadcrumbs)}`
 }
 
+function getSubpageBreadcrumbPrefix(
+  graftParent: PopupMenuNode,
+): BreadcrumbNode[] {
+  const breadcrumbs: BreadcrumbNode[] = []
+  let current: PopupMenuNode | null = graftParent
+
+  while (current) {
+    if (current.def.kind === 'submenu' || current.def.kind === 'subpage') {
+      breadcrumbs.unshift({
+        node: current.def,
+        value: current.def.value,
+        id: current.def.id,
+      })
+    }
+    current = current.parent
+  }
+
+  return breadcrumbs
+}
+
+function prefixDisplayNodeBreadcrumbs(
+  displayNodes: DisplayNode[],
+  prefix: BreadcrumbNode[],
+): DisplayNode[] {
+  if (prefix.length === 0) return displayNodes
+
+  const prefixContext = <C extends { breadcrumbs: BreadcrumbNode[] }>(
+    context: C,
+  ): C => ({
+    ...context,
+    breadcrumbs: [...prefix, ...context.breadcrumbs],
+  })
+
+  return displayNodes.map((displayNode) => {
+    if (isDisplayGroupNode(displayNode)) {
+      return {
+        ...displayNode,
+        context: prefixContext(displayNode.context),
+        items: displayNode.items.map((item) => ({
+          ...item,
+          context: prefixContext(item.context),
+        })),
+      }
+    }
+
+    if (isDisplayRadioGroupNode(displayNode)) {
+      return {
+        ...displayNode,
+        context: prefixContext(displayNode.context),
+        items: displayNode.items.map((item) => ({
+          ...item,
+          context: prefixContext(item.context),
+        })),
+      }
+    }
+
+    if (isDisplaySeparatorNode(displayNode)) {
+      return displayNode
+    }
+
+    return {
+      ...displayNode,
+      context: prefixContext(displayNode.context),
+    }
+  })
+}
+
 const identityQuery = (query: string) => query
+
+function resolvedChildren(node: PopupMenuNode): ResolvedMenuNode[] {
+  return node.children as ResolvedMenuNode[]
+}
+
+function resolvedNodeList(nodes: readonly PopupMenuNode[]): ResolvedMenuNode[] {
+  return nodes as ResolvedMenuNode[]
+}
+
+function isResolvedNodeOfKind<K extends NodeDef['kind']>(
+  node: ResolvedMenuNode,
+  kind: K,
+): node is Extract<ResolvedMenuNode, { kind: K }> {
+  return node.kind === kind
+}
+
+function isResolvedRowNode(
+  node: ResolvedMenuNode,
+): node is Extract<ResolvedMenuNode, { kind: RowNodeDef['kind'] }> {
+  return (
+    node.kind === 'item' ||
+    node.kind === 'radio-item' ||
+    node.kind === 'checkbox-item' ||
+    node.kind === 'submenu' ||
+    node.kind === 'subpage' ||
+    node.kind === 'tree-item'
+  )
+}
 
 function orderDisplayNodesForStreaming(
   displayNodes: DisplayNode[],
@@ -550,19 +632,19 @@ export const DataListInner = React.forwardRef<
   } = props
 
   const resolver = useMenuTreeResolver()
-  const { setResolvedContent } = useDataPopupContext()
+  const { publishResolvedNodes, invalidateResolvedNodes } =
+    useDataPopupContext()
+  const dataSurfaceContext = useDataSurfaceContext()
   const getNodeForDefOrDetached = React.useCallback(
     <D extends NodeDef>(def: D): PopupMenuNode<D> => {
       const resolved = resolver?.getNodeForDef(def)
       if (resolved) return resolved
-      warnOutOfTreeDef(def)
       const getResolvedId = resolver?.getResolvedId ?? defaultGetResolvedId
       return resolveDetachedNode(def, getResolvedId)
     },
     [resolver],
   )
   const graftParent = useGraftPoint()
-  const { depth: surfaceDepth } = useListboxContext()
   const resolverSubpageContext = useMaybeSubpageContext()
   const resolverSubpageStack = useMaybeSubpageStack()
   // Mirrors surface.tsx's isSubpageSurfaceInThisPopup: a data surface
@@ -571,8 +653,6 @@ export const DataListInner = React.forwardRef<
     resolverSubpageContext &&
       resolverSubpageStack?.getSurfaceId(resolverSubpageContext.pageId),
   )
-  const isResolutionRoot = surfaceDepth === 0 && !isSubpageSurface
-
   // Get coordinator for async state
   const coordinator = useAsyncMenuCoordinator()
 
@@ -610,44 +690,82 @@ export const DataListInner = React.forwardRef<
     const rootAsyncData = asyncNodes.find((n) => n.id === '__root__')
     if (!rootAsyncData) return mergedContent
 
-    // When asyncContent is provided, it's the sole data source - use only its results
-    if (asyncContent) {
-      return rootAsyncData.nodes
-    }
-
-    // For root-level DataSurface without asyncContent, append to static content
+    // Async root results are merged with the static content in both modes.
     return [...mergedContent, ...rootAsyncData.nodes]
-  }, [mergedContent, asyncNodes, asyncContent])
+  }, [mergedContent, asyncNodes])
 
   // Feed root-owned resolution. Resolution is load-bearing: render paths read
   // resolved ids. setContent/graft are idempotent with reference
   // fast paths, so render-time calls (incl. StrictMode re-invocations) are
   // safe and cheap when content is unchanged. Subpage surfaces never feed:
   // their rows already belong to the root surface's def tree.
-  React.useMemo(() => {
-    if (!resolver || isSubpageSurface) return
+  const reconciliationVersionRef = React.useRef(0)
+  const reconciliation = React.useMemo(() => {
+    if (!resolver) return 0
     if (graftParent) {
+      const previousPairs = graftParent.children.map(
+        (child) => [child, child.def] as const,
+      )
       resolver.graft(graftParent, contentWithRootAsync)
-    } else if (isResolutionRoot) {
+      const nextPairs = graftParent.children.map(
+        (child) => [child, child.def] as const,
+      )
+      const changed =
+        previousPairs.length !== nextPairs.length ||
+        previousPairs.some(
+          ([node, def], index) =>
+            nextPairs[index]?.[0] !== node || nextPairs[index]?.[1] !== def,
+        )
+      if (changed) reconciliationVersionRef.current += 1
+      return {
+        version: reconciliationVersionRef.current,
+        publishedSnapshot: isSubpageSurface
+          ? null
+          : resolvedNodeList([...graftParent.children]),
+      }
+    }
+    if (!isSubpageSurface) {
       resolver.setContent(contentWithRootAsync)
     }
+    return {
+      version: reconciliationVersionRef.current,
+      publishedSnapshot: isSubpageSurface
+        ? null
+        : resolvedNodeList([...resolver.rootNodes]),
+    }
+  }, [resolver, graftParent, isSubpageSurface, contentWithRootAsync])
+
+  const reconciliationVersion =
+    typeof reconciliation === 'number' ? reconciliation : reconciliation.version
+  const publishedSnapshot =
+    typeof reconciliation === 'number' ? null : reconciliation.publishedSnapshot
+
+  const lastInvalidatedVersionRef = React.useRef(0)
+  React.useEffect(() => {
+    if (
+      isSubpageSurface &&
+      graftParent &&
+      reconciliationVersion > lastInvalidatedVersionRef.current
+    ) {
+      lastInvalidatedVersionRef.current = reconciliationVersion
+      invalidateResolvedNodes()
+    }
   }, [
-    resolver,
+    reconciliationVersion,
     graftParent,
+    invalidateResolvedNodes,
     isSubpageSurface,
-    isResolutionRoot,
-    contentWithRootAsync,
   ])
 
   React.useEffect(() => {
-    if (isSubpageSurface) return
-    setResolvedContent(contentWithRootAsync)
-    return () => {
-      setResolvedContent((current) =>
-        current === contentWithRootAsync ? null : current,
-      )
-    }
-  }, [isSubpageSurface, setResolvedContent, contentWithRootAsync])
+    if (isSubpageSurface || !publishedSnapshot) return
+    return publishResolvedNodes(dataSurfaceContext.listId, publishedSnapshot)
+  }, [
+    dataSurfaceContext.listId,
+    isSubpageSurface,
+    publishResolvedNodes,
+    publishedSnapshot,
+  ])
 
   const streamOrderRef = React.useRef<{
     query: string
@@ -715,8 +833,16 @@ export const DataListInner = React.forwardRef<
       streamOrderRef.current = null
     }
 
+    const breadcrumbPrefix =
+      isSubpageSurface && graftParent
+        ? getSubpageBreadcrumbPrefix(graftParent)
+        : []
+
     return {
-      displayNodes: displayNodesToRender,
+      displayNodes: prefixDisplayNodeBreadcrumbs(
+        displayNodesToRender,
+        breadcrumbPrefix,
+      ),
       isDeepSearching: result.isDeepSearching,
     }
   }, [
@@ -730,6 +856,8 @@ export const DataListInner = React.forwardRef<
     coordinator,
     coordinator?.isAnyLoading,
     coordinator?.loaders,
+    graftParent,
+    isSubpageSurface,
   ])
 
   // Sync orderedItems with the store when display nodes change
@@ -944,7 +1072,9 @@ export const DataListInner = React.forwardRef<
         const submenuAsyncState = getBranchAsyncState(node)
 
         // Static nodes only - async content is handled by the submenu's own DataSurface
-        const staticNodes = node.nodes ?? []
+        const staticNodes = resolvedNodeList(
+          selectResolvedChildren(resolved, node.nodes ?? []),
+        )
 
         // Create breadcrumb node for current submenu (used in child contexts)
         const submenuBreadcrumb: BreadcrumbNode = {
@@ -953,10 +1083,9 @@ export const DataListInner = React.forwardRef<
           id: node.id,
         }
 
-        const submenuRenderNode = (
-          arg: NodeDef | PopupMenuNode,
-        ): React.ReactNode => {
-          const childNode = isPopupMenuNode(arg) ? arg.def : arg
+        const submenuRenderNode = (arg: PopupMenuNode): React.ReactNode => {
+          const resolvedArg = arg as ResolvedMenuNode
+          const childNode = resolvedArg.def
           // Skip separators
           if (childNode.kind === 'separator') {
             return null
@@ -964,13 +1093,14 @@ export const DataListInner = React.forwardRef<
 
           // Handle groups - render the group with its children
           if (childNode.kind === 'group') {
-            const groupItems = childNode.nodes.filter(
-              (n): n is ItemDef | CheckboxItemDef | SubmenuDef | SubpageDef =>
-                (n.kind === 'item' ||
-                  n.kind === 'checkbox-item' ||
-                  n.kind === 'submenu' ||
-                  n.kind === 'subpage') &&
-                !n.hidden,
+            const groupItems = resolvedChildren(resolvedArg).filter(
+              (
+                n,
+              ): n is Extract<ResolvedMenuNode, { kind: RowNodeDef['kind'] }> =>
+                isResolvedRowNode(n) &&
+                n.kind !== 'radio-item' &&
+                n.kind !== 'tree-item' &&
+                !n.def.hidden,
             )
 
             if (groupItems.length === 0) {
@@ -984,14 +1114,14 @@ export const DataListInner = React.forwardRef<
                 breadcrumbs: [...context.breadcrumbs, submenuBreadcrumb],
                 isDeepSearchResult: false,
                 highlighted: false,
-                disabled: item.disabled ?? false,
+                disabled: item.def.disabled ?? false,
                 group: { id: childNode.id, label: childNode.label },
                 tree: null,
               }
 
               return renderRowNode({
                 kind: 'row',
-                node: getNodeForDefOrDetached(item),
+                node: item,
                 context: itemContext,
               })
             })
@@ -1007,7 +1137,7 @@ export const DataListInner = React.forwardRef<
               return (
                 <React.Fragment key={childNode.id}>
                   {childNode.render({
-                    node: getNodeForDefOrDetached(childNode),
+                    node: resolvedArg,
                     props: {},
                     context: {
                       ...groupContext,
@@ -1029,8 +1159,11 @@ export const DataListInner = React.forwardRef<
           }
 
           // Handle radio groups inside submenus
-          if (childNode.kind === 'radio-group') {
-            return renderRadioGroup(childNode, [
+          if (
+            childNode.kind === 'radio-group' &&
+            isResolvedNodeOfKind(resolvedArg, 'radio-group')
+          ) {
+            return renderRadioGroup(resolvedArg, [
               ...context.breadcrumbs,
               submenuBreadcrumb,
             ])
@@ -1038,10 +1171,11 @@ export const DataListInner = React.forwardRef<
 
           // Handle items, checkbox items, submenus, and subpages
           if (
-            childNode.kind !== 'item' &&
-            childNode.kind !== 'checkbox-item' &&
-            childNode.kind !== 'submenu' &&
-            childNode.kind !== 'subpage'
+            !isResolvedRowNode(resolvedArg) ||
+            (resolvedArg.kind !== 'item' &&
+              resolvedArg.kind !== 'checkbox-item' &&
+              resolvedArg.kind !== 'submenu' &&
+              resolvedArg.kind !== 'subpage')
           ) {
             return null
           }
@@ -1060,7 +1194,7 @@ export const DataListInner = React.forwardRef<
           // renderRowNode already wraps in a keyed Fragment
           return renderRowNode({
             kind: 'row',
-            node: getNodeForDefOrDetached(childNode),
+            node: resolvedArg,
             context: childContext,
           })
         }
@@ -1125,9 +1259,10 @@ export const DataListInner = React.forwardRef<
   // Helper to render a radio group
   const renderRadioGroup = React.useCallback(
     (
-      radioGroup: RadioGroupDef,
+      radioGroupNode: ResolvedMenuNodeOf<RadioGroupDef>,
       breadcrumbs: BreadcrumbNode[] = [],
     ): React.ReactNode => {
+      const radioGroup = radioGroupNode.def
       const isDeepSearchResult = breadcrumbs.length > 0
 
       // Build group context
@@ -1139,22 +1274,22 @@ export const DataListInner = React.forwardRef<
       }
 
       // Render children - renderRowNode already wraps in keyed Fragment
-      const childElements = radioGroup.nodes.map((item) => {
-        if (item.hidden) return null
+      const childElements = resolvedChildren(radioGroupNode).map((item) => {
+        if (!isResolvedRowNode(item) || item.def.hidden) return null
 
         const itemContext: RowRenderContext = {
           search: null,
           breadcrumbs,
           isDeepSearchResult,
           highlighted: false,
-          disabled: item.disabled ?? false,
+          disabled: item.def.disabled ?? false,
           group: null,
           tree: null,
         }
 
         return renderRowNode({
           kind: 'row',
-          node: getNodeForDefOrDetached(item),
+          node: item,
           context: itemContext,
           radioGroup: { id: radioGroup.id, label: radioGroup.label },
         })
@@ -1165,7 +1300,7 @@ export const DataListInner = React.forwardRef<
         return (
           <React.Fragment key={radioGroup.id}>
             {radioGroup.render({
-              node: getNodeForDefOrDetached(radioGroup),
+              node: radioGroupNode,
               props: {
                 value: radioGroup.value,
                 onValueChange: radioGroup.onValueChange,
@@ -1194,7 +1329,7 @@ export const DataListInner = React.forwardRef<
             radioGroup.id,
             radioGroup.label,
             radioGroup.renderLabel,
-            getNodeForDefOrDetached(radioGroup),
+            radioGroupNode,
             {
               ...groupContext,
               label: radioGroup.label,
@@ -1206,7 +1341,7 @@ export const DataListInner = React.forwardRef<
         </div>
       )
     },
-    [renderRowNode, getNodeForDefOrDetached],
+    [renderRowNode],
   )
 
   // Build the renderNode function that handles groups, radio groups, and rows

--- a/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
+++ b/packages/react/src/internal/popup-menu/deep-search/data-subpages.tsx
@@ -1,34 +1,32 @@
 'use client'
 
 import * as React from 'react'
-import { useMenuTreeResolver } from '../contexts/menu-tree-resolver-context.js'
-import {
-  defaultGetResolvedId,
-  isPopupMenuNode,
-  resolveDetachedNode,
-} from '../menu-tree/resolve.js'
+import { GraftPointContext } from '../contexts/graft-point-context.js'
 import type { PopupMenuNode } from '../menu-tree/types.js'
 import { useAsyncMenuCoordinator } from './async-coordinator.js'
 import { useDataPopupContext } from './context.js'
-import { warnOutOfTreeDef } from './data-list.js'
 import type {
   AsyncRenderState,
   BreadcrumbNode,
-  CheckboxItemDef,
   DataSubpagesChildrenState,
   DataSubpagesProps,
   DisplaySubpageNode,
   GroupRenderContext,
-  ItemDef,
   NodeDef,
   QueryDependentLoaderConfig,
   RadioGroupDef,
-  RadioItemDef,
+  ResolvedMenuNode,
+  ResolvedMenuNodeOf,
+  RowNodeDef,
   RowRenderContext,
   SubmenuDef,
   SubpageDef,
 } from './types.js'
-import { getAsyncLoaderIdForBranch, getSubpagePageId } from './utils.js'
+import {
+  getAsyncLoaderIdForBranch,
+  getSubpagePageId,
+  selectResolvedChildren,
+} from './utils.js'
 
 interface QueryExecutionState {
   effectiveQuery: string
@@ -126,22 +124,46 @@ function getBranchAsyncState(
   }
 }
 
+function resolvedChildren(node: PopupMenuNode): ResolvedMenuNode[] {
+  return node.children as ResolvedMenuNode[]
+}
+
+function isResolvedNodeOfKind<K extends NodeDef['kind']>(
+  node: ResolvedMenuNode,
+  kind: K,
+): node is Extract<ResolvedMenuNode, { kind: K }> {
+  return node.kind === kind
+}
+
+function isResolvedRowNode(
+  node: ResolvedMenuNode,
+): node is Extract<ResolvedMenuNode, { kind: RowNodeDef['kind'] }> {
+  return (
+    node.kind === 'item' ||
+    node.kind === 'radio-item' ||
+    node.kind === 'checkbox-item' ||
+    node.kind === 'submenu' ||
+    node.kind === 'subpage' ||
+    node.kind === 'tree-item'
+  )
+}
+
 function collectDisplaySubpages(
-  nodes: NodeDef[],
-  getNodeForDef: <D extends NodeDef>(def: D) => PopupMenuNode<D>,
+  nodes: readonly ResolvedMenuNode[],
   breadcrumbs: BreadcrumbNode[] = [],
   group: { id: string; label?: string } | null = null,
 ): DisplaySubpageNode[] {
   const result: DisplaySubpageNode[] = []
 
-  for (const node of nodes) {
+  for (const resolved of nodes) {
+    const node = resolved.def
     if (node.kind === 'separator') {
       continue
     }
 
     if (node.kind === 'group') {
       result.push(
-        ...collectDisplaySubpages(node.nodes, getNodeForDef, breadcrumbs, {
+        ...collectDisplaySubpages(resolvedChildren(resolved), breadcrumbs, {
           id: node.id,
           label: node.label,
         }),
@@ -152,20 +174,25 @@ function collectDisplaySubpages(
     if (node.kind === 'radio-group') {
       if (node.hidden) continue
       result.push(
-        ...collectDisplaySubpages(node.nodes, getNodeForDef, breadcrumbs, null),
+        ...collectDisplaySubpages(
+          resolvedChildren(resolved),
+          breadcrumbs,
+          null,
+        ),
       )
       continue
     }
 
-    if (node.hidden) {
+    if ('hidden' in node && node.hidden) {
       continue
     }
 
     if (node.kind === 'submenu' || node.kind === 'subpage') {
       if (node.kind === 'subpage') {
+        const subpageNode = resolved as PopupMenuNode<SubpageDef>
         result.push({
-          node: getNodeForDef(node),
-          pageId: getSubpagePageId(node, breadcrumbs),
+          node: subpageNode,
+          pageId: getSubpagePageId(subpageNode.def, breadcrumbs),
           context: {
             search: null,
             breadcrumbs,
@@ -178,22 +205,19 @@ function collectDisplaySubpages(
         })
       }
 
-      if (node.nodes) {
-        const breadcrumb: BreadcrumbNode = {
-          node,
-          value: node.value,
-          id: node.id,
-        }
-
-        result.push(
-          ...collectDisplaySubpages(
-            node.nodes,
-            getNodeForDef,
-            [...breadcrumbs, breadcrumb],
-            null,
-          ),
-        )
+      const breadcrumb: BreadcrumbNode = {
+        node,
+        value: node.value,
+        id: node.id,
       }
+
+      result.push(
+        ...collectDisplaySubpages(
+          resolvedChildren(resolved),
+          [...breadcrumbs, breadcrumb],
+          null,
+        ),
+      )
     }
   }
 
@@ -222,31 +246,11 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
   const coordinator = useAsyncMenuCoordinator()
   const searchQuery = coordinator?.searchQuery ?? ''
 
-  const { dataSurfaceContext } = useDataPopupContext()
-  const { resolvedContent } = useDataPopupContext()
-  const resolver = useMenuTreeResolver()
-  const getNodeForDefOrDetached = React.useCallback(
-    <D extends NodeDef>(def: D): PopupMenuNode<D> => {
-      const resolved = resolver?.getNodeForDef(def)
-      if (resolved) return resolved
-      warnOutOfTreeDef(def)
-      const getResolvedId = resolver?.getResolvedId ?? defaultGetResolvedId
-      return resolveDetachedNode(def, getResolvedId)
-    },
-    [resolver],
-  )
-  const getIdForDef = React.useCallback(
-    (def: NodeDef): string => getNodeForDefOrDetached(def).id,
-    [getNodeForDefOrDetached],
-  )
-
-  const content = dataSurfaceContext?.content ?? []
-
-  const mergedContent = resolvedContent ?? content
+  const { resolvedNodes } = useDataPopupContext()
 
   const subpages = React.useMemo(
-    () => collectDisplaySubpages(mergedContent, getNodeForDefOrDetached),
-    [mergedContent, getNodeForDefOrDetached],
+    () => (resolvedNodes ? collectDisplaySubpages(resolvedNodes) : []),
+    [resolvedNodes],
   )
 
   const renderSubpageContent = React.useCallback(
@@ -255,21 +259,17 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
       const node = resolved.def
 
       const renderRowNode = (
-        rowNode:
-          | ItemDef
-          | RadioItemDef
-          | CheckboxItemDef
-          | SubmenuDef
-          | SubpageDef,
+        resolvedRowNode: ResolvedMenuNode,
         rowContext: RowRenderContext,
       ): React.ReactNode => {
-        const rowId = getIdForDef(rowNode)
+        const rowNode = resolvedRowNode.def
+        const rowId = resolvedRowNode.id
 
         if (rowNode.kind === 'item') {
           return (
             <React.Fragment key={rowId}>
               {rowNode.render({
-                node: getNodeForDefOrDetached(rowNode),
+                node: resolvedRowNode,
                 props: {
                   id: rowId,
                   value: rowNode.value,
@@ -292,7 +292,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
           return (
             <React.Fragment key={rowId}>
               {rowNode.render({
-                node: getNodeForDefOrDetached(rowNode),
+                node: resolvedRowNode,
                 props: {
                   id: rowId,
                   value: rowNode.value,
@@ -316,7 +316,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
           return (
             <React.Fragment key={rowId}>
               {rowNode.render({
-                node: getNodeForDefOrDetached(rowNode),
+                node: resolvedRowNode,
                 props: {
                   id: rowId,
                   value: rowNode.value,
@@ -342,27 +342,34 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
             searchQuery,
             coordinator,
           )
-          const staticNodes = rowNode.nodes ?? []
+          const staticNodes = isResolvedNodeOfKind(resolvedRowNode, 'submenu')
+            ? selectResolvedChildren(resolvedRowNode, rowNode.nodes ?? [])
+            : []
           const submenuBreadcrumb: BreadcrumbNode = {
             node: rowNode,
             value: rowNode.value,
             id: rowNode.id,
           }
 
-          const submenuRenderNode = (arg: NodeDef | PopupMenuNode) => {
-            const childNode = isPopupMenuNode(arg) ? arg.def : arg
+          const submenuRenderNode = (arg: PopupMenuNode) => {
+            const resolvedArg = arg as ResolvedMenuNode
+            const childNode = resolvedArg.def
             if (childNode.kind === 'separator') {
               return null
             }
 
             if (childNode.kind === 'group') {
-              const groupItems = childNode.nodes.filter(
-                (n): n is ItemDef | CheckboxItemDef | SubmenuDef | SubpageDef =>
-                  (n.kind === 'item' ||
-                    n.kind === 'checkbox-item' ||
-                    n.kind === 'submenu' ||
-                    n.kind === 'subpage') &&
-                  !n.hidden,
+              const groupItems = resolvedChildren(resolvedArg).filter(
+                (
+                  n,
+                ): n is Extract<
+                  ResolvedMenuNode,
+                  { kind: RowNodeDef['kind'] }
+                > =>
+                  isResolvedRowNode(n) &&
+                  n.kind !== 'radio-item' &&
+                  n.kind !== 'tree-item' &&
+                  !n.def.hidden,
               )
 
               if (groupItems.length === 0) {
@@ -375,7 +382,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                   breadcrumbs: [...rowContext.breadcrumbs, submenuBreadcrumb],
                   isDeepSearchResult: false,
                   highlighted: false,
-                  disabled: item.disabled ?? false,
+                  disabled: item.def.disabled ?? false,
                   group: { id: childNode.id, label: childNode.label },
                   tree: null,
                 }),
@@ -392,7 +399,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                 return (
                   <React.Fragment key={childNode.id}>
                     {childNode.render({
-                      node: getNodeForDefOrDetached(childNode),
+                      node: resolvedArg,
                       props: {},
                       context: {
                         ...groupContext,
@@ -416,23 +423,27 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
               )
             }
 
-            if (childNode.kind === 'radio-group') {
-              return renderRadioGroup(childNode, [
+            if (
+              childNode.kind === 'radio-group' &&
+              isResolvedNodeOfKind(resolvedArg, 'radio-group')
+            ) {
+              return renderRadioGroup(resolvedArg, [
                 ...rowContext.breadcrumbs,
                 submenuBreadcrumb,
               ])
             }
 
             if (
-              childNode.kind !== 'item' &&
-              childNode.kind !== 'checkbox-item' &&
-              childNode.kind !== 'submenu' &&
-              childNode.kind !== 'subpage'
+              !isResolvedRowNode(resolvedArg) ||
+              (resolvedArg.kind !== 'item' &&
+                resolvedArg.kind !== 'checkbox-item' &&
+                resolvedArg.kind !== 'submenu' &&
+                resolvedArg.kind !== 'subpage')
             ) {
               return null
             }
 
-            return renderRowNode(childNode, {
+            return renderRowNode(resolvedArg, {
               search: null,
               breadcrumbs: [...rowContext.breadcrumbs, submenuBreadcrumb],
               isDeepSearchResult: false,
@@ -445,49 +456,58 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
 
           return (
             <React.Fragment key={rowId}>
-              {rowNode.render({
-                node: getNodeForDefOrDetached(rowNode),
-                props: {
-                  id: rowId,
-                  value: rowNode.value,
-                  disabled: rowNode.disabled ?? false,
-                },
-                context: {
-                  ...rowContext,
-                  value: rowNode.value,
-                  disabled: rowNode.disabled ?? false,
-                  async: submenuAsyncState,
-                },
-                nodes: staticNodes,
-                asyncContent: rowNode.asyncNodes,
-                renderNode: submenuRenderNode,
-              })}
+              <GraftPointContext.Provider value={resolvedRowNode}>
+                {rowNode.render({
+                  node: resolvedRowNode,
+                  props: {
+                    id: rowId,
+                    value: rowNode.value,
+                    disabled: rowNode.disabled ?? false,
+                  },
+                  context: {
+                    ...rowContext,
+                    value: rowNode.value,
+                    disabled: rowNode.disabled ?? false,
+                    async: submenuAsyncState,
+                  },
+                  nodes: staticNodes,
+                  asyncContent: rowNode.asyncNodes,
+                  renderNode: submenuRenderNode,
+                })}
+              </GraftPointContext.Provider>
             </React.Fragment>
           )
         }
 
+        if (!isResolvedNodeOfKind(resolvedRowNode, 'subpage')) {
+          return null
+        }
+        const subpageNode = resolvedRowNode.def
         const subpageAsyncState = getBranchAsyncState(
-          rowNode,
+          subpageNode,
           rowContext.breadcrumbs,
           searchQuery,
           coordinator,
         )
-        const targetPageId = getSubpagePageId(rowNode, rowContext.breadcrumbs)
+        const targetPageId = getSubpagePageId(
+          subpageNode,
+          rowContext.breadcrumbs,
+        )
 
         return (
           <React.Fragment key={targetPageId}>
-            {rowNode.renderTrigger({
-              node: getNodeForDefOrDetached(rowNode),
+            {subpageNode.renderTrigger({
+              node: resolvedRowNode,
               props: {
                 id: rowId,
-                value: rowNode.value,
-                disabled: rowNode.disabled ?? false,
+                value: subpageNode.value,
+                disabled: subpageNode.disabled ?? false,
                 targetPageId,
               },
               context: {
                 ...rowContext,
-                value: rowNode.value,
-                disabled: rowNode.disabled ?? false,
+                value: subpageNode.value,
+                disabled: subpageNode.disabled ?? false,
                 async: subpageAsyncState,
               },
             })}
@@ -496,9 +516,10 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
       }
 
       const renderRadioGroup = (
-        radioGroup: RadioGroupDef,
+        radioGroupNode: ResolvedMenuNodeOf<RadioGroupDef>,
         breadcrumbs: BreadcrumbNode[] = [],
       ): React.ReactNode => {
+        const radioGroup = radioGroupNode.def
         const isDeepSearchResult = breadcrumbs.length > 0
 
         const groupContext: GroupRenderContext = {
@@ -508,15 +529,15 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
           isDeepSearchResult,
         }
 
-        const childElements = radioGroup.nodes.map((item) => {
-          if (item.hidden) return null
+        const childElements = resolvedChildren(radioGroupNode).map((item) => {
+          if (!isResolvedRowNode(item) || item.def.hidden) return null
 
           return renderRowNode(item, {
             search: null,
             breadcrumbs,
             isDeepSearchResult,
             highlighted: false,
-            disabled: item.disabled ?? false,
+            disabled: item.def.disabled ?? false,
             group: null,
             tree: null,
           })
@@ -526,7 +547,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
           return (
             <React.Fragment key={radioGroup.id}>
               {radioGroup.render({
-                node: getNodeForDefOrDetached(radioGroup),
+                node: radioGroupNode,
                 props: {
                   value: radioGroup.value,
                   onValueChange: radioGroup.onValueChange,
@@ -557,152 +578,157 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
 
       return (
         <React.Fragment key={pageId}>
-          {node.renderContent({
-            node: resolved,
-            pageId,
-            context: {
-              ...context,
-              value: node.value,
-              disabled: node.disabled ?? false,
-              async: getBranchAsyncState(
-                node,
-                context.breadcrumbs,
-                searchQuery,
-                coordinator,
-              ),
-            },
-            nodes: node.nodes ?? [],
-            asyncContent: node.asyncNodes,
-            renderNode: (arg) => {
-              const childNode = isPopupMenuNode(arg) ? arg.def : arg
-              if (childNode.kind === 'separator') {
-                return null
-              }
-
-              if (childNode.kind === 'group') {
-                const groupItems = childNode.nodes.filter(
-                  (
-                    n,
-                  ): n is ItemDef | CheckboxItemDef | SubmenuDef | SubpageDef =>
-                    (n.kind === 'item' ||
-                      n.kind === 'checkbox-item' ||
-                      n.kind === 'submenu' ||
-                      n.kind === 'subpage') &&
-                    !n.hidden,
-                )
-
-                if (groupItems.length === 0) {
+          <GraftPointContext.Provider value={resolved}>
+            {node.renderContent({
+              node: resolved,
+              pageId,
+              context: {
+                ...context,
+                value: node.value,
+                disabled: node.disabled ?? false,
+                async: getBranchAsyncState(
+                  node,
+                  context.breadcrumbs,
+                  searchQuery,
+                  coordinator,
+                ),
+              },
+              nodes: selectResolvedChildren(resolved, node.nodes ?? []),
+              asyncContent: node.asyncNodes,
+              renderNode: (arg) => {
+                const resolvedArg = arg as ResolvedMenuNode
+                const childNode = resolvedArg.def
+                if (childNode.kind === 'separator') {
                   return null
                 }
 
-                const groupChildren = groupItems.map((item) =>
-                  renderRowNode(item, {
-                    search: null,
-                    breadcrumbs: [
-                      ...context.breadcrumbs,
-                      {
-                        node,
-                        value: node.value,
-                        id: node.id,
-                      },
-                    ],
-                    isDeepSearchResult: false,
-                    highlighted: false,
-                    disabled: item.disabled ?? false,
-                    group: { id: childNode.id, label: childNode.label },
-                    tree: null,
-                  }),
-                )
+                if (childNode.kind === 'group') {
+                  const groupItems = resolvedChildren(resolvedArg).filter(
+                    (
+                      n,
+                    ): n is Extract<
+                      ResolvedMenuNode,
+                      { kind: RowNodeDef['kind'] }
+                    > =>
+                      isResolvedRowNode(n) &&
+                      n.kind !== 'radio-item' &&
+                      n.kind !== 'tree-item' &&
+                      !n.def.hidden,
+                  )
 
-                if (childNode.render) {
-                  const groupContext: GroupRenderContext = {
-                    search: null,
-                    matchCount: groupItems.length,
-                    breadcrumbs: [
-                      ...context.breadcrumbs,
-                      {
-                        node,
-                        value: node.value,
-                        id: node.id,
-                      },
-                    ],
-                    isDeepSearchResult: false,
+                  if (groupItems.length === 0) {
+                    return null
+                  }
+
+                  const groupChildren = groupItems.map((item) =>
+                    renderRowNode(item, {
+                      search: null,
+                      breadcrumbs: [
+                        ...context.breadcrumbs,
+                        {
+                          node,
+                          value: node.value,
+                          id: node.id,
+                        },
+                      ],
+                      isDeepSearchResult: false,
+                      highlighted: false,
+                      disabled: item.def.disabled ?? false,
+                      group: { id: childNode.id, label: childNode.label },
+                      tree: null,
+                    }),
+                  )
+
+                  if (childNode.render) {
+                    const groupContext: GroupRenderContext = {
+                      search: null,
+                      matchCount: groupItems.length,
+                      breadcrumbs: [
+                        ...context.breadcrumbs,
+                        {
+                          node,
+                          value: node.value,
+                          id: node.id,
+                        },
+                      ],
+                      isDeepSearchResult: false,
+                    }
+
+                    return (
+                      <React.Fragment key={childNode.id}>
+                        {childNode.render({
+                          node: arg,
+                          props: {},
+                          context: {
+                            ...groupContext,
+                            label: childNode.label,
+                          },
+                          children: <>{groupChildren}</>,
+                        })}
+                      </React.Fragment>
+                    )
                   }
 
                   return (
-                    <React.Fragment key={childNode.id}>
-                      {childNode.render({
-                        node: getNodeForDefOrDetached(childNode),
-                        props: {},
-                        context: {
-                          ...groupContext,
-                          label: childNode.label,
-                        },
-                        children: <>{groupChildren}</>,
-                      })}
-                    </React.Fragment>
+                    // biome-ignore lint/a11y/useSemanticElements: ignore for now
+                    <div
+                      key={childNode.id}
+                      role="group"
+                      aria-label={childNode.label}
+                    >
+                      {groupChildren}
+                    </div>
                   )
                 }
 
-                return (
-                  // biome-ignore lint/a11y/useSemanticElements: ignore for now
-                  <div
-                    key={childNode.id}
-                    role="group"
-                    aria-label={childNode.label}
-                  >
-                    {groupChildren}
-                  </div>
-                )
-              }
+                if (
+                  childNode.kind === 'radio-group' &&
+                  isResolvedNodeOfKind(resolvedArg, 'radio-group')
+                ) {
+                  return renderRadioGroup(resolvedArg, [
+                    ...context.breadcrumbs,
+                    {
+                      node,
+                      value: node.value,
+                      id: node.id,
+                    },
+                  ])
+                }
 
-              if (childNode.kind === 'radio-group') {
-                return renderRadioGroup(childNode, [
-                  ...context.breadcrumbs,
-                  {
-                    node,
-                    value: node.value,
-                    id: node.id,
-                  },
-                ])
-              }
+                if (
+                  !isResolvedRowNode(resolvedArg) ||
+                  (resolvedArg.kind !== 'item' &&
+                    resolvedArg.kind !== 'checkbox-item' &&
+                    resolvedArg.kind !== 'submenu' &&
+                    resolvedArg.kind !== 'subpage')
+                ) {
+                  return null
+                }
 
-              if (
-                childNode.kind !== 'item' &&
-                childNode.kind !== 'checkbox-item' &&
-                childNode.kind !== 'submenu' &&
-                childNode.kind !== 'subpage'
-              ) {
-                return null
-              }
-
-              return renderRowNode(childNode, {
-                search: null,
-                breadcrumbs: [
-                  ...context.breadcrumbs,
-                  {
-                    node,
-                    value: node.value,
-                    id: node.id,
-                  },
-                ],
-                isDeepSearchResult: false,
-                highlighted: false,
-                disabled: childNode.disabled ?? false,
-                group: null,
-                tree: null,
-              })
-            },
-          })}
+                return renderRowNode(resolvedArg, {
+                  search: null,
+                  breadcrumbs: [
+                    ...context.breadcrumbs,
+                    {
+                      node,
+                      value: node.value,
+                      id: node.id,
+                    },
+                  ],
+                  isDeepSearchResult: false,
+                  highlighted: false,
+                  disabled: childNode.disabled ?? false,
+                  group: null,
+                  tree: null,
+                })
+              },
+            })}
+          </GraftPointContext.Provider>
         </React.Fragment>
       )
     },
-    [coordinator, searchQuery, getIdForDef],
+    [coordinator, searchQuery],
   )
-
-  if (!dataSurfaceContext) {
-    return null
-  }
 
   const childrenState: DataSubpagesChildrenState = {
     subpages,

--- a/packages/react/src/internal/popup-menu/deep-search/types.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/types.ts
@@ -490,23 +490,12 @@ export interface SubmenuRenderParams {
     /** Async loading state (if asyncNodes configured) */
     async?: AsyncRenderState
   }
-  /**
-   * The submenu's static child node definitions.
-   * Does NOT include async results - use `asyncContent` for that.
-   */
-  nodes: NodeDef[]
-  /**
-   * Async content configuration for this submenu.
-   * Pass this to the submenu's DataSurface to enable async loading
-   * with the submenu's own search query (independent of parent search).
-   */
+  /** Callback-time snapshot of the child definitions selected by the renderer; not a live collection. `node.def` exposes authored data. */
+  nodes: PopupMenuNode[]
+  /** Async content configuration for this submenu. */
   asyncContent?: AsyncNodesConfig
-  /**
-   * Function to render a child node.
-   * Call this for each node in the submenu's list.
-   */
-  /** Resolved nodes are unwrapped to their defs. */
-  renderNode: (node: NodeDef | PopupMenuNode) => React.ReactNode
+  /** Render a resolver-owned child Menu Node. */
+  renderNode: (node: PopupMenuNode) => React.ReactNode
 }
 
 // ============================================================================
@@ -569,23 +558,12 @@ export interface SubpageContentRenderParams {
     /** Async loading state (if asyncNodes configured) */
     async?: AsyncRenderState
   }
-  /**
-   * The subpage's static child node definitions.
-   * Does NOT include async results - use `asyncContent` for that.
-   */
-  nodes: NodeDef[]
-  /**
-   * Async content configuration for this subpage.
-   * Pass this to the subpage's DataSurface to enable async loading
-   * with the subpage's own search query (independent of parent search).
-   */
+  /** Callback-time snapshot of the child definitions selected by the renderer; not a live collection. `node.def` exposes authored data. */
+  nodes: PopupMenuNode[]
+  /** Async content configuration for this subpage. */
   asyncContent?: AsyncNodesConfig
-  /**
-   * Function to render a child node.
-   * Call this for each node in the subpage's list.
-   */
-  /** Resolved nodes are unwrapped to their defs. */
-  renderNode: (node: NodeDef | PopupMenuNode) => React.ReactNode
+  /** Render a resolver-owned child Menu Node. */
+  renderNode: (node: PopupMenuNode) => React.ReactNode
 }
 
 // ============================================================================
@@ -1072,6 +1050,21 @@ export type NodeDef =
   | SeparatorDef
   | GroupDef
   | RadioGroupDef
+
+/** A discriminated union of resolver-owned Menu Nodes. */
+export type ResolvedMenuNode =
+  | PopupMenuNode<ItemDef>
+  | PopupMenuNode<TreeItemDef>
+  | PopupMenuNode<RadioItemDef>
+  | PopupMenuNode<CheckboxItemDef>
+  | PopupMenuNode<SubmenuDef>
+  | PopupMenuNode<SubpageDef>
+  | PopupMenuNode<SeparatorDef>
+  | PopupMenuNode<GroupDef>
+  | PopupMenuNode<RadioGroupDef>
+
+/** A resolver-owned Menu Node narrowed to one authored definition family. */
+export type ResolvedMenuNodeOf<D extends NodeDef> = PopupMenuNode<D>
 
 // ============================================================================
 // Scored Node - internal type for search results

--- a/packages/react/src/internal/popup-menu/deep-search/utils.ts
+++ b/packages/react/src/internal/popup-menu/deep-search/utils.ts
@@ -22,12 +22,45 @@ import type {
   RadioGroupBehavior,
   RadioGroupDef,
   RadioItemDef,
+  ResolvedMenuNode,
   RowRenderContext,
   ScoredNode,
   SubmenuDef,
   SubpageDef,
   TreeItemDef,
 } from './types.js'
+
+/** Select renderer-owned children by exact definition identity and occurrence. */
+export function selectResolvedChildren(
+  parent: PopupMenuNode,
+  selectedDefs: readonly NodeDef[],
+): ResolvedMenuNode[] {
+  const selectedCounts = new Map<NodeDef, number>()
+  for (const def of selectedDefs) {
+    selectedCounts.set(def, (selectedCounts.get(def) ?? 0) + 1)
+  }
+  const matches = new Map<NodeDef, PopupMenuNode[]>()
+  for (const child of parent.children) {
+    if (!selectedCounts.has(child.def)) continue
+    const bucket = matches.get(child.def) ?? []
+    bucket.push(child)
+    matches.set(child.def, bucket)
+  }
+  for (const [def, count] of selectedCounts) {
+    if ((matches.get(def)?.length ?? 0) !== count) {
+      throw new Error(
+        '[PopupMenu] Renderer-selected child definitions cannot be matched unambiguously to the resolved parent.',
+      )
+    }
+  }
+  const offsets = new Map<NodeDef, number>()
+  return selectedDefs.map((def) => {
+    const bucket = matches.get(def)!
+    const index = offsets.get(def) ?? 0
+    offsets.set(def, index + 1)
+    return bucket[index]! as ResolvedMenuNode
+  })
+}
 
 const identityQuery = (query: string) => query
 

--- a/packages/react/src/internal/popup-menu/hooks/use-subpage-stack-state.ts
+++ b/packages/react/src/internal/popup-menu/hooks/use-subpage-stack-state.ts
@@ -49,7 +49,7 @@ export function useSubpageStackState(
   const subpagesRef = React.useRef<
     Map<string, { surfaceId: string; closeRootOnEsc: boolean }>
   >(new Map())
-  const [, setSubpageRegistryVersion] = React.useState(0)
+  const [subpageRegistryVersion, setSubpageRegistryVersion] = React.useState(0)
   const [isSubpageNavigating, setIsSubpageNavigating] = React.useState(false)
   const subpageNavigatingTimerRef = React.useRef<ReturnType<
     typeof setTimeout
@@ -190,8 +190,10 @@ export function useSubpageStackState(
   const subpageId = openSubpageIds[openSubpageIds.length - 1] ?? null
   const hasOpenSubpage = subpageId !== null
 
-  const subpageStackContextValue = React.useMemo(
-    () => ({
+  const subpageStackContextValue = React.useMemo(() => {
+    void subpageRegistryVersion
+
+    return {
       activePageId,
       activeSurfaceId,
       canGoBack,
@@ -201,19 +203,19 @@ export function useSubpageStackState(
       openPage,
       goBack,
       getSurfaceId,
-    }),
-    [
-      activePageId,
-      activeSurfaceId,
-      canGoBack,
-      shouldCloseRootOnEsc,
-      subpageStack,
-      registerPage,
-      openPage,
-      goBack,
-      getSurfaceId,
-    ],
-  )
+    }
+  }, [
+    subpageRegistryVersion,
+    activePageId,
+    activeSurfaceId,
+    canGoBack,
+    shouldCloseRootOnEsc,
+    subpageStack,
+    registerPage,
+    openPage,
+    goBack,
+    getSurfaceId,
+  ])
 
   return {
     subpageStackContextValue,


### PR DESCRIPTION
## TL;DR
Require submenu and subpage render callbacks to consume resolver-owned Menu Nodes, preserving scoped identity across nested, async, and sibling popup surfaces.

## Motivation
Raw Node Def callback inputs could be rendered outside their resolved ancestry, producing detached or stale IDs. Popup sibling handoff also needed atomic ownership so temporary subpage navigation and real List or Surface withdrawal are distinguished safely.

## What's changed
- Changed callback `nodes` and `renderNode` contracts to use `PopupMenuNode` snapshots selected by exact parent-local definition occurrence.
- Added atomic token/source/node publication shared by command and popup menus, including deferred withdrawal and StrictMode-safe replacement.
- Preserved nested submenu graft ownership, repeated async graft invalidation, dynamic subpage registration, and full branch breadcrumbs.
- Added lifecycle, fresh-definition, shared-parent, allowlist, async nested-page, and static-plus-async regressions.
- Removed detached-node callback documentation and added a migration changeset.