### PR TITLE
docs: establish domain vocabulary contexts, ADR, and ship integration

### DIFF
--- a/.agents/ship.md
+++ b/.agents/ship.md
@@ -18,6 +18,16 @@ Note: this team has a `Canary` state (merged to canary branch, published as cana
 - Changesets: `bun run changeset` to add; publish scripts in root `package.json` (`ci:publish` lists packages explicitly — new publishable packages must be added there)
 - No DB/migrations in this repo (demo DB for examples lives in `apps/web` with `drizzle.config.ts` + seed script when present)
 
+## Vocabulary
+
+This repo maintains a domain glossary. Presence of this section enables ship's vocabulary behaviors (see the ship skill's config gates).
+
+- **Map**: `CONTEXT-MAP.md` (repo root) — read it first; it lists the contexts and their relationships.
+- **Contexts**: `packages/react/CONTEXT.md` (consumer-facing component language) and `packages/react/src/internal/popup-menu/CONTEXT.md` (engine-internal identity/resolution language). Placement principle: if a consumer must speak the term, it belongs in the react context; if only maintainers speak it, the engine context.
+- **ADRs**: `docs/adr/` (system-wide). Offer ADRs per the `domain-modeling` skill's three criteria.
+- **Discipline**: specs and issues use canonical terms and respect each entry's *Avoid* list; reviewers treat avoid-list violations as findings. New or contested terms are resolved via the `domain-modeling` skill, not improvised.
+- **Explore-phase vocabulary**: when the first new term crystallises during `ship explore`, lazily create a placeholder issue — title `Explore: <topic>`, Backlog, label `exploration` — and a worktree from its branch name (`wt switch -c <gitBranchName>`); commit vocabulary changes there so they ride the exploration's lifecycle. Two-track rule: vocabulary naming *existing* code may go straight to a trunk-bound branch (or a `ship quick`); vocabulary for *not-yet-built* concepts stays in the exploration worktree. At closeout the placeholder is promoted (linked to/replaced by the plan's parent issue) or canceled with a reason; `ship reconcile` sweeps zombie `exploration` placeholders.
+
 ## Reference repositories
 
 None.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,11 @@
+# Context Map
+
+## Contexts
+
+- [Popup Menu](./packages/react/src/internal/popup-menu/CONTEXT.md) — the data-first popup-menu engine: node defs resolved into a menu tree, rendered, filtered, and deep-searched
+- [React Components](./packages/react/CONTEXT.md) — the consumer-facing component library in `@bazza-ui/react`: families, parts, and the authoring vocabulary they share
+
+## Relationships
+
+- **React Components → Popup Menu**: the menu family's members (`dropdown-menu`, `context-menu`, `combobox`, `command-menu`, `select`) are consumer-facing shells over the internal popup-menu engine. Engine vocabulary (node def, menu node, graft) stays internal; only `Node` surfaces on each family's namespace.
+- **Popup Menu borrows from React Components**: the anatomy and interaction vocabulary (surface, popup, submenu, subpage, focus zone, highlight) is defined in React Components — consumer language — and used freely in the engine context without redefinition.

--- a/docs/adr/0001-keep-node-as-tree-vocabulary.md
+++ b/docs/adr/0001-keep-node-as-tree-vocabulary.md
@@ -1,0 +1,11 @@
+# Keep "node" as the menu-tree vocabulary despite the ReactNode collision
+
+The popup-menu engine's public vocabulary (`NodeDef`, `renderNode`, `Node` on all five menu-family namespaces) uses "node", which collides with `React.ReactNode`, DOM `Node`, and Node.js. We considered renaming during the 2026-08 vocabulary session and decided to keep "node": the engine is a tree, and its surrounding vocabulary — menu tree, graft, definition path, parent/children — only reads correctly with tree terminology. In practice the term is almost always qualified ("node def", "menu node"), which defuses the collision.
+
+## Considered Options
+
+- **entry** — "menu entry" reads well for items, but "grafting entries" and "entry tree" lose the tree precision, and groups containing entries stop sounding like a tree.
+- **row** — already taken with a narrower meaning (row id = identity of one displayable line); a group is not a row, it contains rows. Merging would blur a distinction the identity model depends on.
+- **item / option / command / element** — each collides with an existing part name, a single family's connotation, or React's own vocabulary.
+
+Renaming touches public API across five namespaces, so reversing this later is expensive — do not reintroduce the debate without new evidence of real-world confusion.

--- a/packages/react/CONTEXT.md
+++ b/packages/react/CONTEXT.md
@@ -1,0 +1,75 @@
+# React Components
+
+The consumer-facing component library: `@bazza-ui/react` exports unstyled primitives; the registry distributes their styled counterparts. Both are components — the axis is styled vs primitive, not component vs primitive.
+
+All terms are common nouns: sentence case in prose ("the composable API", "a subpage"), capitalized only where English demands it or when naming a part (`DropdownMenu.Subpage`).
+
+## Language
+
+**Primitive**:
+An unstyled compound component exported from `@bazza-ui/react` (e.g. `DropdownMenu`), composed of parts under one namespace.
+_Avoid_: unstyled component, headless component, base component
+
+**Family**:
+A category of related library offerings. The **menu family** is the set backed by the popup-menu engine: dropdown-menu, context-menu, combobox, command-menu, select — each a **member** of the family. "Member" is relational only, never a label: refer to a member by its proper name ("the dropdown menu", "the dropdown menu docs"), not "the dropdown-menu member".
+_Avoid_: suite, cluster, category; "the dropdown-menu family" (a family is the group, not one member)
+
+**Highlight**:
+The single visually-emphasized row of a popup — what arrow keys move and `data-highlighted` styles. Distinct from DOM focus (which stays on the input, trigger, or a focus zone; highlight is virtual — DOM focus never moves to rows) and from selection (checked/chosen state).
+_Avoid_: active item, focused item
+
+**Focus Zone**:
+A region of a surface, registered with it, that participates in tab navigation — Tab moves real DOM focus through its interactive content. Arrow-key navigation and highlight remain the listbox's job; a focus zone is where DOM focus is allowed to go inside the popup.
+_Avoid_: focus trap, focus region, tab group
+
+**Composable API**:
+Authoring menu content by composing parts directly as JSX (`<DropdownMenu.Item>` inside `<DropdownMenu.List>`). The substrate API: even data-first render functions bottom out in composable parts.
+_Avoid_: compositional API, JSX API, manual API
+
+**Data-first API**:
+Authoring menu content as node defs — plain data the engine resolves, filters, and deep-searches — with render functions for presentation. Layered on the composable API; scoped to content (rows), while scaffolding parts (surface, input, list) stay composable.
+_Avoid_: node API, data API, declarative API (both APIs are declarative)
+
+**Loader**:
+A source of node defs fetched after mount, created via a loader factory; results graft under the loader's parent node. Two kinds: a **static loader** fetches once; a **query loader** fetches per search query. The loader concept is agnostic to any data-fetching solution.
+_Avoid_: fetcher, data source, async source
+
+**Adapter**:
+The binding that lets a data-fetching solution drive the loader pattern. Vanilla, SWR, and TanStack Query adapters ship in the package; consumers can write their own.
+_Avoid_: integration, plugin, connector
+
+**Part**:
+One renderable component exported on a primitive's namespace, addressed as `Primitive.PartName` (e.g. `DropdownMenu.Trigger`). Surfaced types on the namespace (e.g. `DropdownMenu.Node`) are namespace exports, not parts — parts render.
+_Avoid_: subcomponent, piece, element
+
+**Submenu**:
+A nested menu that opens in its own floating popup alongside its parent; the parent stays visible. Spatial nesting. Deep search flattens across submenu boundaries the same as subpage boundaries.
+_Avoid_: nested menu, child menu, flyout
+
+**Subpage**:
+A drill-in navigation that renders a sibling surface inside the same popup, with a back affordance; the parent surface is hidden until navigated back. Temporal nesting.
+_Avoid_: page, drill-down, nested view
+
+**Surface**:
+One self-contained menu pane: a list of items plus optionally an input, header, footer, and focus zone. A popup contains one or more surfaces — the root surface and one sibling surface per open subpage.
+_Avoid_: panel, pane, view
+
+**Popup**:
+The floating container a positioner places on screen; wraps its surfaces. Each menu level that floats independently — the root, and each open submenu — is its own popup.
+_Avoid_: popover (for menus), overlay, floating panel
+
+**Styled Component**:
+The styled, copy-paste counterpart of a primitive, distributed via the registry (`registry/ui/`). No relation to the `styled-components` library.
+_Avoid_: ui component, pre-styled component, component (bare — "component" alone means any React component and never disambiguates styled from primitive)
+
+**Registry**:
+The copy-paste distribution channel served by the web app: styled components, examples, and blocks.
+_Avoid_: component library (that's the npm package), template gallery
+
+**Example**:
+A runnable demo — of a primitive or of a styled component — embedded in the docs page it belongs to.
+_Avoid_: demo, snippet, recipe
+
+**Block**:
+A larger composed unit in the registry: a whole feature composition (e.g. `filters-01`) rather than one component.
+_Avoid_: template, section

--- a/packages/react/src/internal/popup-menu/CONTEXT.md
+++ b/packages/react/src/internal/popup-menu/CONTEXT.md
@@ -53,6 +53,10 @@ _Avoid_: merge, inject, append
 The stable placeholder node produced for a def that is rendered but is not part of the resolved tree (a consumer passing an arbitrary def to `renderNode`). Dev-warned once per def; its id is root-relative rather than path-qualified. Not a supported authoring pattern — memoize defs and prefer explicit ids.
 _Avoid_: orphan node, temp node
 
+**Listbox**:
+The state layer beneath the engine: rows register into a `ListboxStore`, which owns highlight state and keyboard navigation. Implements the WAI-ARIA listbox pattern; shared by every menu family.
+_Avoid_: list store, selection engine
+
 ## Removed vocabulary
 
 These terms described the string-based identity model and no longer exist in the code. They appear here only so the names are not reintroduced with new meanings.


### PR DESCRIPTION
## Summary

Establishes the repo's shared domain vocabulary as versioned docs: a context map, two context glossaries, a naming ADR, and the ship config section that wires the vocabulary into the agent workflow.

## Changes

- `CONTEXT-MAP.md` (new) — declares the two bounded contexts (React Components, Popup Menu), their relationship, and the borrow rule for anatomy vocabulary
- `packages/react/CONTEXT.md` (new) — consumer-facing glossary: primitive, styled component, part, family/member, surface, popup, submenu, subpage, highlight, focus zone, composable API, data-first API, loader (static/query), adapter, registry, example, block
- `CONTEXT.md` → `packages/react/src/internal/popup-menu/CONTEXT.md` (moved) — the engine glossary relocates next to the engine; gains a **Listbox** entry
- `docs/adr/0001-keep-node-as-tree-vocabulary.md` (new) — records why `node` (`NodeDef`, `renderNode`, `Node`) survives the `ReactNode` collision, with rejected alternatives
- `.agents/ship.md` — new `## Vocabulary` section enabling ship's vocabulary behaviors (canonical terms in specs, avoid-list review findings, explore-phase vocabulary lifecycle)

## Motivation

The popup-menu glossary sat at the repo root pretending to be the whole domain, while the much larger consumer-facing vocabulary (parts, surfaces, subpages, the two authoring APIs, the registry) had no written language at all — every doc, spec, and agent session improvised its own words. Terms were resolved in a structured vocabulary session (2026-08); the split is by audience: consumer language lives at the package level, engine-internal identity/resolution language lives with the engine. Follow-ups already tracked: [UI-495](https://linear.app/bazzalabs/issue/UI-495/rename-bazza-uireactadapters-subpath-to-loaders) (adapters → loaders subpath), and #465 (registry directory rename) stacks on this PR.

## Tests

No automated tests — documentation and agent-workflow config only. Verified `bun run check` reports no new diagnostics (Biome does not process these markdown files) and that no references to the old root `CONTEXT.md` path exist in the repo.

Closes [UI-496](https://linear.app/bazzalabs/issue/UI-496/add-domain-vocabulary-contexts-adr-and-ship-config)
