### PR TITLE
feat(popup-menu): add `closeOnPointerLeave` prop to `SubmenuTrigger`

### DIFF
--- a/.changeset/submenu-close-on-pointer-leave.md
+++ b/.changeset/submenu-close-on-pointer-leave.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': minor
+---
+
+Add `closeOnPointerLeave` prop to `SubmenuTrigger` (DropdownMenu / ContextMenu) to keep a submenu open when the pointer leaves its trigger.

--- a/apps/web/.types/types-meta.json
+++ b/apps/web/.types/types-meta.json
@@ -1348,395 +1348,6 @@
   "@bazza-ui/react": {
     "entrypoint": "../../packages/react/src/docs-types-entry.ts",
     "types": {
-      "CreateSWRQueryLoaderProps": {
-        "name": "CreateSWRQueryLoaderProps",
-        "kind": "interface",
-        "doc": "Props for creating a query-dependent SWR loader component.",
-        "props": [
-          {
-            "name": "useSWR",
-            "type": "(query: string, options?: { enabled: boolean; } | undefined) => SWRResult<NodeDef[], Error>",
-            "formattedType": "(\n  query: string,\n  options?: { enabled: boolean } | undefined,\n) => SWRResult<NodeDef[], Error>",
-            "required": true,
-            "description": "Hook that returns an SWR result based on the search query.\n`options.enabled` can be used to derive a `null` key and disable fetching."
-          },
-          {
-            "name": "minQueryLength",
-            "type": "number | undefined",
-            "formattedType": "number",
-            "required": false,
-            "description": "Minimum query length before fetching.",
-            "default": "1"
-          },
-          {
-            "name": "initialQueryBehavior",
-            "type": "false | InitialQueryBehavior | undefined",
-            "formattedType": "false | InitialQueryBehavior",
-            "required": false,
-            "description": "Initial query behavior before user input reaches minQueryLength.\nDefaults to fetching with an empty query."
-          },
-          {
-            "name": "initialQuery",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false
-          },
-          {
-            "name": "loadStrategy",
-            "type": "\"eager\" | \"lazy\" | undefined",
-            "formattedType": "\"eager\" | \"lazy\"",
-            "required": false,
-            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens (good for deep search)\n- 'lazy': Load when submenu opens (default)",
-            "default": "'lazy'"
-          },
-          {
-            "name": "belowMinBehavior",
-            "type": "\"empty\" | \"placeholder\" | undefined",
-            "formattedType": "\"empty\" | \"placeholder\"",
-            "required": false,
-            "description": "What to show when query is below minQueryLength.",
-            "default": "'empty'"
-          },
-          {
-            "name": "placeholderNodes",
-            "type": "NodeDef[] | undefined",
-            "formattedType": "NodeDef[]",
-            "required": false,
-            "description": "Placeholder nodes shown when query is below minQueryLength."
-          }
-        ]
-      },
-      "CreateSWRStaticLoaderProps": {
-        "name": "CreateSWRStaticLoaderProps",
-        "kind": "interface",
-        "doc": "Props for creating a static SWR loader component.",
-        "props": [
-          {
-            "name": "useSWR",
-            "type": "() => SWRResult<NodeDef[], Error>",
-            "required": true,
-            "description": "Hook that returns an SWR result."
-          },
-          {
-            "name": "loadStrategy",
-            "type": "\"eager\" | \"lazy\" | undefined",
-            "formattedType": "\"eager\" | \"lazy\"",
-            "required": false,
-            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens\n- 'lazy': Load when submenu opens (default)"
-          }
-        ]
-      },
-      "SWRResult": {
-        "name": "SWRResult",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData"
-          },
-          {
-            "name": "TError",
-            "default": "Error"
-          }
-        ],
-        "doc": "SWR result shape (subset of SWRResponse).\nThis allows the adapter to work without requiring `swr` as a dependency.",
-        "props": [
-          {
-            "name": "data",
-            "type": "TData | undefined",
-            "formattedType": "TData",
-            "required": true
-          },
-          {
-            "name": "error",
-            "type": "TError | undefined",
-            "formattedType": "TError",
-            "required": true
-          },
-          {
-            "name": "isLoading",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false
-          },
-          {
-            "name": "isValidating",
-            "type": "boolean",
-            "formattedType": "false | true",
-            "required": true
-          },
-          {
-            "name": "isPaused",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false
-          },
-          {
-            "name": "mutate",
-            "type": "(...args: unknown[]) => unknown",
-            "required": true
-          }
-        ]
-      },
-      "CreateQueryLoaderProps": {
-        "name": "CreateQueryLoaderProps",
-        "kind": "interface",
-        "doc": "Props for creating a query loader component.",
-        "props": [
-          {
-            "name": "useQuery",
-            "type": "(query: string, options?: { enabled: boolean; } | undefined) => TanStackQueryResult<NodeDef[], Error>",
-            "formattedType": "(\n  query: string,\n  options?: { enabled: boolean } | undefined,\n) => TanStackQueryResult<NodeDef[], Error>",
-            "required": true,
-            "description": "Hook that returns a TanStack Query result based on the search query.\nThis hook will be called inside the loader component with the current query."
-          },
-          {
-            "name": "minQueryLength",
-            "type": "number | undefined",
-            "formattedType": "number",
-            "required": false,
-            "description": "Minimum query length before fetching.",
-            "default": "1"
-          },
-          {
-            "name": "initialQueryBehavior",
-            "type": "false | InitialQueryBehavior | undefined",
-            "formattedType": "false | InitialQueryBehavior",
-            "required": false,
-            "description": "Initial query behavior before user input reaches minQueryLength.\nDefaults to fetching with an empty query."
-          },
-          {
-            "name": "initialQuery",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false
-          },
-          {
-            "name": "loadStrategy",
-            "type": "\"eager\" | \"lazy\" | undefined",
-            "formattedType": "\"eager\" | \"lazy\"",
-            "required": false,
-            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens (good for deep search)\n- 'lazy': Load when submenu opens (default)",
-            "default": "'lazy'"
-          },
-          {
-            "name": "belowMinBehavior",
-            "type": "\"empty\" | \"placeholder\" | undefined",
-            "formattedType": "\"empty\" | \"placeholder\"",
-            "required": false,
-            "description": "What to show when query is below minQueryLength.",
-            "default": "'empty'"
-          },
-          {
-            "name": "placeholderNodes",
-            "type": "NodeDef[] | undefined",
-            "formattedType": "NodeDef[]",
-            "required": false,
-            "description": "Placeholder nodes shown when query is below minQueryLength."
-          }
-        ]
-      },
-      "CreateStaticLoaderProps": {
-        "name": "CreateStaticLoaderProps",
-        "kind": "interface",
-        "doc": "Props for creating a static loader component.",
-        "props": [
-          {
-            "name": "useQuery",
-            "type": "() => TanStackQueryResult<NodeDef[], Error>",
-            "formattedType": "() => TanStackQueryResult<\n  NodeDef[],\n  Error\n>",
-            "required": true,
-            "description": "Hook that returns a TanStack Query result.\nThis hook will be called inside the loader component."
-          },
-          {
-            "name": "loadStrategy",
-            "type": "\"eager\" | \"lazy\" | undefined",
-            "formattedType": "\"eager\" | \"lazy\"",
-            "required": false,
-            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens\n- 'lazy': Load when submenu opens (default)"
-          }
-        ]
-      },
-      "TanStackQueryResult": {
-        "name": "TanStackQueryResult",
-        "kind": "interface",
-        "typeParams": [
-          {
-            "name": "TData"
-          },
-          {
-            "name": "TError",
-            "default": "Error"
-          }
-        ],
-        "doc": "TanStack Query result shape (subset of UseQueryResult).\nThis allows the adapter to work without requiring",
-        "props": [
-          {
-            "name": "status",
-            "type": "\"error\" | \"pending\" | \"success\" | undefined",
-            "formattedType": "\"error\" | \"pending\" | \"success\"",
-            "required": false,
-            "description": "TanStack status (`pending` | `error` | `success`)"
-          },
-          {
-            "name": "fetchStatus",
-            "type": "\"paused\" | \"idle\" | \"fetching\" | undefined",
-            "formattedType": "\"paused\" | \"idle\" | \"fetching\"",
-            "required": false,
-            "description": "TanStack fetch status (`fetching` | `paused` | `idle`)"
-          },
-          {
-            "name": "data",
-            "type": "TData | undefined",
-            "formattedType": "TData",
-            "required": true
-          },
-          {
-            "name": "error",
-            "type": "TError | null | undefined",
-            "formattedType": "null | TError",
-            "required": true
-          },
-          {
-            "name": "isLoading",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "v5: true when first fetch is in-flight"
-          },
-          {
-            "name": "isPending",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "v5: true when status is pending"
-          },
-          {
-            "name": "isSuccess",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "true when status is success"
-          },
-          {
-            "name": "isError",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "true when status is error"
-          },
-          {
-            "name": "isFetching",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "true while any fetch is in-flight"
-          },
-          {
-            "name": "isRefetching",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "true while background refetch is in-flight"
-          },
-          {
-            "name": "isPaused",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "true when fetch is paused"
-          },
-          {
-            "name": "isFetched",
-            "type": "boolean | undefined",
-            "formattedType": "false | true",
-            "required": false,
-            "description": "true once query has fetched at least once"
-          },
-          {
-            "name": "refetch",
-            "type": "() => unknown",
-            "required": true
-          }
-        ]
-      },
-      "CreateVanillaQueryLoaderProps": {
-        "name": "CreateVanillaQueryLoaderProps",
-        "kind": "interface",
-        "doc": "Props for creating a query loader with vanilla fetch.",
-        "props": [
-          {
-            "name": "fetcher",
-            "type": "(query: string, options?: { signal?: AbortSignal | undefined; } | undefined) => Promise<NodeDef[]>",
-            "formattedType": "(\n  query: string,\n  options?:\n    | { signal?: AbortSignal | undefined }\n    | undefined,\n) => Promise<NodeDef[]>",
-            "required": true,
-            "description": "Async function that fetches menu items based on the search query.\nReceives an optional `signal` that is aborted when a newer query is issued,\nallowing you to cancel in-flight requests (e.g. pass it to `fetch()`)."
-          },
-          {
-            "name": "minQueryLength",
-            "type": "number | undefined",
-            "formattedType": "number",
-            "required": false,
-            "description": "Minimum query length before fetching.",
-            "default": "1"
-          },
-          {
-            "name": "initialQueryBehavior",
-            "type": "false | InitialQueryBehavior | undefined",
-            "formattedType": "false | InitialQueryBehavior",
-            "required": false,
-            "description": "Initial query behavior before user input reaches minQueryLength.\nDefaults to fetching with an empty query."
-          },
-          {
-            "name": "initialQuery",
-            "type": "string | undefined",
-            "formattedType": "string",
-            "required": false
-          },
-          {
-            "name": "loadStrategy",
-            "type": "\"eager\" | \"lazy\" | undefined",
-            "formattedType": "\"eager\" | \"lazy\"",
-            "required": false,
-            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens (good for deep search)\n- 'lazy': Load when submenu opens (default)",
-            "default": "'lazy'"
-          },
-          {
-            "name": "belowMinBehavior",
-            "type": "\"empty\" | \"placeholder\" | undefined",
-            "formattedType": "\"empty\" | \"placeholder\"",
-            "required": false,
-            "description": "What to show when query is below minQueryLength.",
-            "default": "'empty'"
-          },
-          {
-            "name": "placeholderNodes",
-            "type": "NodeDef[] | undefined",
-            "formattedType": "NodeDef[]",
-            "required": false,
-            "description": "Placeholder nodes shown when query is below minQueryLength."
-          }
-        ]
-      },
-      "CreateVanillaStaticLoaderProps": {
-        "name": "CreateVanillaStaticLoaderProps",
-        "kind": "interface",
-        "doc": "Props for creating a static loader with vanilla fetch.",
-        "props": [
-          {
-            "name": "fetcher",
-            "type": "() => Promise<NodeDef[]>",
-            "required": true,
-            "description": "Async function that fetches the menu items."
-          },
-          {
-            "name": "loadStrategy",
-            "type": "\"eager\" | \"lazy\" | undefined",
-            "formattedType": "\"eager\" | \"lazy\"",
-            "required": false,
-            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens\n- 'lazy': Load when submenu opens (default)"
-          }
-        ]
-      },
       "ComboboxClearProps": {
         "name": "ComboboxClearProps",
         "kind": "interface",
@@ -2547,8 +2158,8 @@
           },
           {
             "name": "content",
-            "type": "PopupMenuNode<NodeDef>[] | NodeDef[] | undefined",
-            "formattedType": "PopupMenuNode<NodeDef>[] | NodeDef[]",
+            "type": "NodeDef[] | PopupMenuNode<NodeDef>[] | undefined",
+            "formattedType": "NodeDef[] | PopupMenuNode<NodeDef>[]",
             "required": false,
             "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity."
           },
@@ -4269,10 +3880,10 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((node: PopupMenuNode<NodeDef> | null, id: string | null, index: number, eventDetails: ContextMenuHighlightChangeEventDetails) => void) | undefined",
-            "formattedType": "(\n  node: PopupMenuNode<NodeDef> | null,\n  id: string | null,\n  index: number,\n  eventDetails: ContextMenuHighlightChangeEventDetails,\n) => void",
+            "type": "PopupMenuHighlightChangeHandler<ContextMenuHighlightChangeEventDetails> | undefined",
+            "formattedType": "PopupMenuHighlightChangeHandler<ContextMenuHighlightChangeEventDetails>",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\n`node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.\nThe fourth parameter contains event details including the reason for the change."
+            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\n`id` is first. `node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.\nThe fourth parameter contains event details including the reason for the change."
           },
           {
             "name": "disabled",
@@ -6087,10 +5698,10 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((node: PopupMenuNode<NodeDef> | null, id: string | null, index: number, eventDetails: GenericEventDetails<string, { index: number; }>) => void) | undefined",
-            "formattedType": "(\n  node: PopupMenuNode<NodeDef> | null,\n  id: string | null,\n  index: number,\n  eventDetails: GenericEventDetails<\n    string,\n    { index: number }\n  >,\n) => void",
+            "type": "PopupMenuHighlightChangeHandler<HighlightChangeEventDetails> | undefined",
+            "formattedType": "PopupMenuHighlightChangeHandler<HighlightChangeEventDetails>",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex)."
+            "description": "Callback when the highlighted item changes. `id` is first; `node` is the\nresolved menu node enrichment and may be null.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex)."
           },
           {
             "name": "onOpenChangeComplete",
@@ -6232,6 +5843,14 @@
             "required": false,
             "description": "Delay before closing the submenu when pointer leaves (in milliseconds).",
             "default": "0"
+          },
+          {
+            "name": "closeOnPointerLeave",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether the submenu closes when the pointer leaves the trigger without aiming at the submenu popup.\nWhen `false`, the submenu stays open until closed by another path (sibling highlight, keyboard, outside click, etc.).",
+            "default": "true"
           },
           {
             "name": "forceOrder",
@@ -6807,8 +6426,8 @@
           },
           {
             "name": "content",
-            "type": "PopupMenuNode<NodeDef>[] | NodeDef[] | undefined",
-            "formattedType": "PopupMenuNode<NodeDef>[] | NodeDef[]",
+            "type": "NodeDef[] | PopupMenuNode<NodeDef>[] | undefined",
+            "formattedType": "NodeDef[] | PopupMenuNode<NodeDef>[]",
             "required": false,
             "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity."
           },
@@ -8238,6 +7857,12 @@
             "default": "true"
           },
           {
+            "name": "children",
+            "type": "ReactNode",
+            "required": false,
+            "description": "Children (used for text content inference when value is not provided)."
+          },
+          {
             "name": "keywords",
             "type": "string[] | undefined",
             "formattedType": "string[]",
@@ -8266,12 +7891,6 @@
             "formattedType": "() => void",
             "required": false,
             "description": "Callback when this item is selected (via click or Enter key).\nFor simple items, pass this directly. For checkbox/radio items,\nuse registerSelect() to register a dynamic handler."
-          },
-          {
-            "name": "children",
-            "type": "ReactNode",
-            "required": false,
-            "description": "Children (used for text content inference when value is not provided)."
           }
         ]
       },
@@ -10518,10 +10137,10 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((node: PopupMenuNode<NodeDef> | null, id: string | null, index: number, eventDetails: DropdownMenuHighlightChangeEventDetails) => void) | undefined",
-            "formattedType": "(\n  node: PopupMenuNode<NodeDef> | null,\n  id: string | null,\n  index: number,\n  eventDetails: DropdownMenuHighlightChangeEventDetails,\n) => void",
+            "type": "PopupMenuHighlightChangeHandler<DropdownMenuHighlightChangeEventDetails> | undefined",
+            "formattedType": "PopupMenuHighlightChangeHandler<DropdownMenuHighlightChangeEventDetails>",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\n`node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.\nThe fourth parameter contains event details including the reason for the change."
+            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex) or other UI state.\n`id` is first. `node` is the resolved menu node carrying the highlighted id, looked up in the menu's data-first tree — `null` when the highlight clears or when no data-first node carries that id (e.g. JSX-defined rows). A JSX row that shares an id with a data-first node yields that node; row ids are expected to be unique per menu.\nThe fourth parameter contains event details including the reason for the change."
           },
           {
             "name": "closeOnOutsidePress",
@@ -12371,10 +11990,10 @@
           },
           {
             "name": "onHighlightChange",
-            "type": "((node: PopupMenuNode<NodeDef> | null, id: string | null, index: number, eventDetails: GenericEventDetails<string, { index: number; }>) => void) | undefined",
-            "formattedType": "(\n  node: PopupMenuNode<NodeDef> | null,\n  id: string | null,\n  index: number,\n  eventDetails: GenericEventDetails<\n    string,\n    { index: number }\n  >,\n) => void",
+            "type": "PopupMenuHighlightChangeHandler<HighlightChangeEventDetails> | undefined",
+            "formattedType": "PopupMenuHighlightChangeHandler<HighlightChangeEventDetails>",
             "required": false,
-            "description": "Callback when the highlighted item changes.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex)."
+            "description": "Callback when the highlighted item changes. `id` is first; `node` is the\nresolved menu node enrichment and may be null.\nUseful for synchronizing with a virtualizer (e.g., scrollToIndex)."
           },
           {
             "name": "onOpenChangeComplete",
@@ -12516,6 +12135,14 @@
             "required": false,
             "description": "Delay before closing the submenu when pointer leaves (in milliseconds).",
             "default": "0"
+          },
+          {
+            "name": "closeOnPointerLeave",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "Whether the submenu closes when the pointer leaves the trigger without aiming at the submenu popup.\nWhen `false`, the submenu stays open until closed by another path (sibling highlight, keyboard, outside click, etc.).",
+            "default": "true"
           },
           {
             "name": "forceOrder",
@@ -13091,11 +12718,11 @@
           },
           {
             "name": "content",
-            "type": "PopupMenuNode<NodeDef>[] | NodeDef[] | undefined",
-            "formattedType": "PopupMenuNode<NodeDef>[] | NodeDef[]",
+            "type": "NodeDef[] | PopupMenuNode<NodeDef>[] | undefined",
+            "formattedType": "NodeDef[] | PopupMenuNode<NodeDef>[]",
             "required": false,
             "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity.",
-            "referencePath": "@bazza-ui/react.PopupMenuNode"
+            "referencePath": "@bazza-ui/react.NodeDef"
           },
           {
             "name": "asyncContent",
@@ -14666,7 +14293,7 @@
       "QueryAsyncNodesConfig": {
         "name": "QueryAsyncNodesConfig",
         "kind": "typealias",
-        "doc": "Query-dependent async nodes configuration for submenus.",
+        "doc": "Query async nodes configuration for submenus.",
         "definition": "QueryLoaderConfig",
         "props": [
           {
@@ -14732,7 +14359,7 @@
       "QueryLoaderConfig": {
         "name": "QueryLoaderConfig",
         "kind": "interface",
-        "doc": "Query-dependent loader configuration.\nRefetches based on search query - server does the filtering.",
+        "doc": "Query loader configuration.\nRefetches based on search query - server does the filtering.",
         "props": [
           {
             "name": "type",
@@ -15051,6 +14678,398 @@
             "required": false,
             "description": "When to trigger the loader:\n- 'eager': Load when menu opens (good for deep search)\n- 'lazy': Load when submenu opens (default)",
             "default": "'lazy'"
+          }
+        ]
+      },
+      "CreateSWRQueryLoaderProps": {
+        "name": "CreateSWRQueryLoaderProps",
+        "kind": "interface",
+        "doc": "Props for creating a query SWR loader component.",
+        "props": [
+          {
+            "name": "useSWR",
+            "type": "(query: string, options?: { enabled: boolean; } | undefined) => SWRResult<NodeDef[], Error>",
+            "formattedType": "(\n  query: string,\n  options?: { enabled: boolean } | undefined,\n) => SWRResult<NodeDef[], Error>",
+            "required": true,
+            "description": "Hook that returns an SWR result based on the search query.\n`options.enabled` can be used to derive a `null` key and disable fetching."
+          },
+          {
+            "name": "minQueryLength",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Minimum query length before fetching.",
+            "default": "1"
+          },
+          {
+            "name": "initialQueryBehavior",
+            "type": "false | InitialQueryBehavior | undefined",
+            "formattedType": "false | InitialQueryBehavior",
+            "required": false,
+            "description": "Initial query behavior before user input reaches minQueryLength.\nDefaults to fetching with an empty query."
+          },
+          {
+            "name": "initialQuery",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
+            "required": false,
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens (good for deep search)\n- 'lazy': Load when submenu opens (default)",
+            "default": "'lazy'"
+          },
+          {
+            "name": "belowMinBehavior",
+            "type": "\"empty\" | \"placeholder\" | undefined",
+            "formattedType": "\"empty\" | \"placeholder\"",
+            "required": false,
+            "description": "What to show when query is below minQueryLength.",
+            "default": "'empty'"
+          },
+          {
+            "name": "placeholderNodes",
+            "type": "NodeDef[] | undefined",
+            "formattedType": "NodeDef[]",
+            "required": false,
+            "description": "Placeholder nodes shown when query is below minQueryLength.",
+            "referencePath": "@bazza-ui/react.NodeDef"
+          }
+        ]
+      },
+      "CreateSWRStaticLoaderProps": {
+        "name": "CreateSWRStaticLoaderProps",
+        "kind": "interface",
+        "doc": "Props for creating a static SWR loader component.",
+        "props": [
+          {
+            "name": "useSWR",
+            "type": "() => SWRResult<NodeDef[], Error>",
+            "required": true,
+            "description": "Hook that returns an SWR result."
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
+            "required": false,
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens\n- 'lazy': Load when submenu opens (default)"
+          }
+        ]
+      },
+      "SWRResult": {
+        "name": "SWRResult",
+        "kind": "interface",
+        "typeParams": [
+          {
+            "name": "TData"
+          },
+          {
+            "name": "TError",
+            "default": "Error"
+          }
+        ],
+        "doc": "SWR result shape (subset of SWRResponse).\nThis allows the adapter to work without requiring `swr` as a dependency.",
+        "props": [
+          {
+            "name": "data",
+            "type": "TData | undefined",
+            "formattedType": "TData",
+            "required": true
+          },
+          {
+            "name": "error",
+            "type": "TError | undefined",
+            "formattedType": "TError",
+            "required": true
+          },
+          {
+            "name": "isLoading",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false
+          },
+          {
+            "name": "isValidating",
+            "type": "boolean",
+            "formattedType": "false | true",
+            "required": true
+          },
+          {
+            "name": "isPaused",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false
+          },
+          {
+            "name": "mutate",
+            "type": "(...args: unknown[]) => unknown",
+            "required": true
+          }
+        ]
+      },
+      "CreateQueryLoaderProps": {
+        "name": "CreateQueryLoaderProps",
+        "kind": "interface",
+        "doc": "Props for creating a query loader component.",
+        "props": [
+          {
+            "name": "useQuery",
+            "type": "(query: string, options?: { enabled: boolean; } | undefined) => TanStackQueryResult<NodeDef[], Error>",
+            "formattedType": "(\n  query: string,\n  options?: { enabled: boolean } | undefined,\n) => TanStackQueryResult<NodeDef[], Error>",
+            "required": true,
+            "description": "Hook that returns a TanStack Query result based on the search query.\nThis hook will be called inside the loader component with the current query."
+          },
+          {
+            "name": "minQueryLength",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Minimum query length before fetching.",
+            "default": "1"
+          },
+          {
+            "name": "initialQueryBehavior",
+            "type": "false | InitialQueryBehavior | undefined",
+            "formattedType": "false | InitialQueryBehavior",
+            "required": false,
+            "description": "Initial query behavior before user input reaches minQueryLength.\nDefaults to fetching with an empty query."
+          },
+          {
+            "name": "initialQuery",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
+            "required": false,
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens (good for deep search)\n- 'lazy': Load when submenu opens (default)",
+            "default": "'lazy'"
+          },
+          {
+            "name": "belowMinBehavior",
+            "type": "\"empty\" | \"placeholder\" | undefined",
+            "formattedType": "\"empty\" | \"placeholder\"",
+            "required": false,
+            "description": "What to show when query is below minQueryLength.",
+            "default": "'empty'"
+          },
+          {
+            "name": "placeholderNodes",
+            "type": "NodeDef[] | undefined",
+            "formattedType": "NodeDef[]",
+            "required": false,
+            "description": "Placeholder nodes shown when query is below minQueryLength.",
+            "referencePath": "@bazza-ui/react.NodeDef"
+          }
+        ]
+      },
+      "CreateStaticLoaderProps": {
+        "name": "CreateStaticLoaderProps",
+        "kind": "interface",
+        "doc": "Props for creating a static loader component.",
+        "props": [
+          {
+            "name": "useQuery",
+            "type": "() => TanStackQueryResult<NodeDef[], Error>",
+            "formattedType": "() => TanStackQueryResult<\n  NodeDef[],\n  Error\n>",
+            "required": true,
+            "description": "Hook that returns a TanStack Query result.\nThis hook will be called inside the loader component."
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
+            "required": false,
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens\n- 'lazy': Load when submenu opens (default)"
+          }
+        ]
+      },
+      "TanStackQueryResult": {
+        "name": "TanStackQueryResult",
+        "kind": "interface",
+        "typeParams": [
+          {
+            "name": "TData"
+          },
+          {
+            "name": "TError",
+            "default": "Error"
+          }
+        ],
+        "doc": "TanStack Query result shape (subset of UseQueryResult).\nThis allows the adapter to work without requiring",
+        "props": [
+          {
+            "name": "status",
+            "type": "\"error\" | \"pending\" | \"success\" | undefined",
+            "formattedType": "\"error\" | \"pending\" | \"success\"",
+            "required": false,
+            "description": "TanStack status (`pending` | `error` | `success`)"
+          },
+          {
+            "name": "fetchStatus",
+            "type": "\"paused\" | \"idle\" | \"fetching\" | undefined",
+            "formattedType": "\"paused\" | \"idle\" | \"fetching\"",
+            "required": false,
+            "description": "TanStack fetch status (`fetching` | `paused` | `idle`)"
+          },
+          {
+            "name": "data",
+            "type": "TData | undefined",
+            "formattedType": "TData",
+            "required": true
+          },
+          {
+            "name": "error",
+            "type": "TError | null | undefined",
+            "formattedType": "null | TError",
+            "required": true
+          },
+          {
+            "name": "isLoading",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "v5: true when first fetch is in-flight"
+          },
+          {
+            "name": "isPending",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "v5: true when status is pending"
+          },
+          {
+            "name": "isSuccess",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "true when status is success"
+          },
+          {
+            "name": "isError",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "true when status is error"
+          },
+          {
+            "name": "isFetching",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "true while any fetch is in-flight"
+          },
+          {
+            "name": "isRefetching",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "true while background refetch is in-flight"
+          },
+          {
+            "name": "isPaused",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "true when fetch is paused"
+          },
+          {
+            "name": "isFetched",
+            "type": "boolean | undefined",
+            "formattedType": "false | true",
+            "required": false,
+            "description": "true once query has fetched at least once"
+          },
+          {
+            "name": "refetch",
+            "type": "() => unknown",
+            "required": true
+          }
+        ]
+      },
+      "CreateVanillaQueryLoaderProps": {
+        "name": "CreateVanillaQueryLoaderProps",
+        "kind": "interface",
+        "doc": "Props for creating a query loader with vanilla fetch.",
+        "props": [
+          {
+            "name": "fetcher",
+            "type": "(query: string, options?: { signal?: AbortSignal | undefined; } | undefined) => Promise<NodeDef[]>",
+            "formattedType": "(\n  query: string,\n  options?:\n    | { signal?: AbortSignal | undefined }\n    | undefined,\n) => Promise<NodeDef[]>",
+            "required": true,
+            "description": "Async function that fetches menu items based on the search query.\nReceives an optional `signal` that is aborted when a newer query is issued,\nallowing you to cancel in-flight requests (e.g. pass it to `fetch()`)."
+          },
+          {
+            "name": "minQueryLength",
+            "type": "number | undefined",
+            "formattedType": "number",
+            "required": false,
+            "description": "Minimum query length before fetching.",
+            "default": "1"
+          },
+          {
+            "name": "initialQueryBehavior",
+            "type": "false | InitialQueryBehavior | undefined",
+            "formattedType": "false | InitialQueryBehavior",
+            "required": false,
+            "description": "Initial query behavior before user input reaches minQueryLength.\nDefaults to fetching with an empty query."
+          },
+          {
+            "name": "initialQuery",
+            "type": "string | undefined",
+            "formattedType": "string",
+            "required": false
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
+            "required": false,
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens (good for deep search)\n- 'lazy': Load when submenu opens (default)",
+            "default": "'lazy'"
+          },
+          {
+            "name": "belowMinBehavior",
+            "type": "\"empty\" | \"placeholder\" | undefined",
+            "formattedType": "\"empty\" | \"placeholder\"",
+            "required": false,
+            "description": "What to show when query is below minQueryLength.",
+            "default": "'empty'"
+          },
+          {
+            "name": "placeholderNodes",
+            "type": "NodeDef[] | undefined",
+            "formattedType": "NodeDef[]",
+            "required": false,
+            "description": "Placeholder nodes shown when query is below minQueryLength.",
+            "referencePath": "@bazza-ui/react.NodeDef"
+          }
+        ]
+      },
+      "CreateVanillaStaticLoaderProps": {
+        "name": "CreateVanillaStaticLoaderProps",
+        "kind": "interface",
+        "doc": "Props for creating a static loader with vanilla fetch.",
+        "props": [
+          {
+            "name": "fetcher",
+            "type": "() => Promise<NodeDef[]>",
+            "required": true,
+            "description": "Async function that fetches the menu items."
+          },
+          {
+            "name": "loadStrategy",
+            "type": "\"eager\" | \"lazy\" | undefined",
+            "formattedType": "\"eager\" | \"lazy\"",
+            "required": false,
+            "description": "When to trigger the loader:\n- 'eager': Load when root menu opens\n- 'lazy': Load when submenu opens (default)"
           }
         ]
       },
@@ -16806,11 +16825,11 @@
           },
           {
             "name": "content",
-            "type": "PopupMenuNode<NodeDef>[] | NodeDef[] | undefined",
-            "formattedType": "PopupMenuNode<NodeDef>[] | NodeDef[]",
+            "type": "NodeDef[] | PopupMenuNode<NodeDef>[] | undefined",
+            "formattedType": "NodeDef[] | PopupMenuNode<NodeDef>[]",
             "required": false,
             "description": "The menu content (node definitions with render functions). Resolved nodes\nare accepted anywhere defs are; they are unwrapped to their defs, and\nre-supplying the same nodes preserves identity.",
-            "referencePath": "@bazza-ui/react.PopupMenuNode"
+            "referencePath": "@bazza-ui/react.NodeDef"
           },
           {
             "name": "render",

--- a/packages/react/src/internal/popup-menu/components/submenu-trigger/submenu-trigger.tsx
+++ b/packages/react/src/internal/popup-menu/components/submenu-trigger/submenu-trigger.tsx
@@ -137,6 +137,13 @@ export interface PopupMenuSubmenuTriggerProps
   closeDelay?: number
 
   /**
+   * Whether the submenu closes when the pointer leaves the trigger without aiming at the submenu popup.
+   * When `false`, the submenu stays open until closed by another path (sibling highlight, keyboard, outside click, etc.).
+   * @default true
+   */
+  closeOnPointerLeave?: boolean
+
+  /**
    * Forces this row's relative order during score-based sorting.
    * Lower values appear earlier.
    * @default 0
@@ -176,6 +183,7 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
     openOnHighlight = true,
     delay: delayProp,
     closeDelay = 0,
+    closeOnPointerLeave = true,
     forceOrder,
     forceScore,
     render,
@@ -242,6 +250,10 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
   }, [])
 
   const scheduleClose = React.useCallback(() => {
+    if (!closeOnPointerLeave) {
+      return
+    }
+
     clearCloseTimer()
 
     if (closeDelay <= 0) {
@@ -253,7 +265,7 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
       closeTimerRef.current = null
       setOpen(false)
     }, closeDelay)
-  }, [clearCloseTimer, closeDelay, setOpen])
+  }, [clearCloseTimer, closeDelay, closeOnPointerLeave, setOpen])
 
   const clearLeaveMonitor = React.useCallback(() => {
     if (leaveMonitorCleanupRef.current) {
@@ -520,7 +532,7 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
           clearAimGuard()
           scheduleClose()
 
-          if (closeDelay <= 0) {
+          if (closeDelay <= 0 || !closeOnPointerLeave) {
             clearLeaveMonitor()
           }
 
@@ -590,7 +602,7 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
         clearAimGuard()
         scheduleClose()
 
-        if (closeDelay <= 0) {
+        if (closeDelay <= 0 || !closeOnPointerLeave) {
           clearLeaveMonitor()
         }
       }
@@ -628,6 +640,7 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
       clearAimGuard,
       scheduleClose,
       closeDelay,
+      closeOnPointerLeave,
     ],
   )
 
@@ -1206,7 +1219,9 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
         showMissedSafeTriangle(debugSnapshot)
         clearAimGuard()
         scheduleClose()
-        if (closeDelay > 0) {
+        if (!closeOnPointerLeave) {
+          clearLeaveMonitor()
+        } else if (closeDelay > 0) {
           startLeaveMonitor(anchor, tRect, false, closeDelay, clientX, clientY)
         } else {
           clearLeaveMonitor()
@@ -1223,6 +1238,7 @@ export const PopupMenuSubmenuTrigger = React.forwardRef<
       item.id,
       item.storeId,
       closeDelay,
+      closeOnPointerLeave,
       contentRef,
       clearLeaveMonitor,
       clearMissSafeTriangleTimer,

--- a/packages/react/src/internal/popup-menu/popup-menu.test.tsx
+++ b/packages/react/src/internal/popup-menu/popup-menu.test.tsx
@@ -746,6 +746,7 @@ function FocusOwnershipSyncMenu() {
 function NestedMenuForDataAttrs({
   debug,
   submenuCloseDelay,
+  submenuCloseOnPointerLeave,
 }: {
   debug?: {
     showSafeTriangleArea?:
@@ -770,6 +771,7 @@ function NestedMenuForDataAttrs({
     logAimGuardEvents?: boolean
   }
   submenuCloseDelay?: number
+  submenuCloseOnPointerLeave?: boolean
 } = {}) {
   return (
     <DropdownMenu.Root debug={debug}>
@@ -788,6 +790,7 @@ function NestedMenuForDataAttrs({
                   <DropdownMenu.SubmenuTrigger
                     data-testid="submenu-trigger-1"
                     closeDelay={submenuCloseDelay}
+                    closeOnPointerLeave={submenuCloseOnPointerLeave}
                   >
                     Submenu 1
                   </DropdownMenu.SubmenuTrigger>
@@ -2119,6 +2122,138 @@ describe('PopupMenu', () => {
           },
           { timeout: 700 },
         )
+      } finally {
+        scenario.cleanup()
+      }
+    })
+  })
+
+  describe('submenu closeOnPointerLeave', () => {
+    const setupScenario = async (closeDelay = 0) => {
+      const user = userEvent.setup()
+      render(
+        <NestedMenuForDataAttrs
+          submenuCloseOnPointerLeave={false}
+          submenuCloseDelay={closeDelay}
+        />,
+      )
+
+      await user.click(screen.getByTestId('trigger'))
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-root')).toBeInTheDocument()
+      })
+
+      const submenuTrigger = screen.getByTestId('submenu-trigger-1')
+      await user.hover(submenuTrigger)
+      await waitFor(() => {
+        expect(screen.getByTestId('popup-submenu-1')).toBeInTheDocument()
+      })
+
+      const submenuPopup = screen.getByTestId('popup-submenu-1')
+      const triggerRectSpy = vi
+        .spyOn(submenuTrigger, 'getBoundingClientRect')
+        .mockImplementation(() =>
+          createRect({ top: 60, left: 80, width: 120, height: 30 }),
+        )
+      const popupRectSpy = vi
+        .spyOn(submenuPopup, 'getBoundingClientRect')
+        .mockImplementation(() =>
+          createRect({ top: 40, left: 240, width: 180, height: 160 }),
+        )
+
+      return {
+        user,
+        submenuTrigger,
+        cleanup: () => {
+          triggerRectSpy.mockRestore()
+          popupRectSpy.mockRestore()
+        },
+      }
+    }
+
+    const fireMissTrajectory = (submenuTrigger: HTMLElement) => {
+      fireEvent.pointerEnter(submenuTrigger, { clientX: 180, clientY: 220 })
+      fireEvent.pointerMove(window, { clientX: 180, clientY: 220 })
+      fireEvent.pointerMove(window, { clientX: 160, clientY: 230 })
+      fireEvent.pointerMove(window, { clientX: 140, clientY: 240 })
+      fireEvent.pointerLeave(submenuTrigger, { clientX: 130, clientY: 260 })
+    }
+
+    it('keeps the submenu open on a miss when closeOnPointerLeave is false', async () => {
+      const scenario = await setupScenario()
+
+      try {
+        fireMissTrajectory(scenario.submenuTrigger)
+        await new Promise((r) => setTimeout(r, 300))
+        expect(screen.getByTestId('popup-submenu-1')).toBeInTheDocument()
+      } finally {
+        scenario.cleanup()
+      }
+    })
+
+    it('still closes when a sibling item is highlighted', async () => {
+      const scenario = await setupScenario()
+
+      try {
+        fireMissTrajectory(scenario.submenuTrigger)
+        // Prove the miss itself did not close it, so the removal below is
+        // attributable to the sibling highlight.
+        expect(screen.getByTestId('popup-submenu-1')).toBeInTheDocument()
+
+        const rootItem = screen.getByTestId('root-item-1')
+        fireEvent.pointerEnter(rootItem, { clientX: 100, clientY: 20 })
+        fireEvent.pointerMove(rootItem, { clientX: 102, clientY: 22 })
+
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId('popup-submenu-1'),
+          ).not.toBeInTheDocument()
+        })
+      } finally {
+        scenario.cleanup()
+      }
+    })
+
+    it('stops the leave monitor after a reversal so a sibling highlight is not undone (closeDelay > 0)', async () => {
+      const scenario = await setupScenario(240)
+
+      try {
+        // Initial hit trajectory toward the submenu → leave monitor starts
+        fireEvent.pointerMove(window, { clientX: 120, clientY: 90 })
+        fireEvent.pointerMove(window, { clientX: 150, clientY: 92 })
+        fireEvent.pointerMove(window, { clientX: 180, clientY: 94 })
+        fireEvent.pointerLeave(scenario.submenuTrigger, {
+          clientX: 190,
+          clientY: 94,
+        })
+        expect(screen.getByTestId('popup-submenu-1')).toBeInTheDocument()
+
+        // Reverse away from the submenu → miss; with closeOnPointerLeave=false
+        // the popup must stay open, and the monitor must be torn down.
+        fireEvent.pointerMove(window, { clientX: 178, clientY: 94 })
+        fireEvent.pointerMove(window, { clientX: 164, clientY: 94 })
+        expect(screen.getByTestId('popup-submenu-1')).toBeInTheDocument()
+
+        // Highlight a sibling → closes the submenu via closeSiblingSubmenus.
+        const rootItem = screen.getByTestId('root-item-1')
+        fireEvent.pointerEnter(rootItem, { clientX: 96, clientY: 74 })
+        fireEvent.pointerMove(rootItem, { clientX: 100, clientY: 78 })
+
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId('popup-submenu-1'),
+          ).not.toBeInTheDocument()
+        })
+
+        // A stale monitor could re-evaluate a later move as a "hit" and reopen
+        // the submenu / steal the highlight back. Move toward where the popup
+        // was and confirm the sibling highlight and closed state are stable.
+        fireEvent.pointerMove(window, { clientX: 200, clientY: 100 })
+        fireEvent.pointerMove(window, { clientX: 230, clientY: 110 })
+        await sleep(300)
+
+        expect(screen.queryByTestId('popup-submenu-1')).not.toBeInTheDocument()
+        expect(rootItem).toHaveAttribute('data-highlighted', '')
       } finally {
         scenario.cleanup()
       }


### PR DESCRIPTION
## Summary

Adds a `closeOnPointerLeave` prop (default `true`) to `SubmenuTrigger` so consumers can keep a submenu open when the pointer leaves its trigger without aiming at the popup.

## Changes

- `PopupMenuSubmenuTrigger` (`packages/react/src/internal/popup-menu/components/submenu-trigger/submenu-trigger.tsx`): new `closeOnPointerLeave?: boolean` prop. `scheduleClose` no-ops when it is `false`, which gates the pointer-leave miss path, the no-content-rect path, and the leave-monitor miss/reversal transitions. The miss branch of `handlePointerLeave` also skips starting the delayed-close leave monitor, and the miss/reversal transitions inside `startLeaveMonitor` tear the monitor down when the prop is `false` (previously only when `closeDelay <= 0`), so a stale window listener can't later re-highlight the trigger and reopen the submenu.
- Changeset (`@bazza-ui/react` minor).
- `apps/web/.types/types-meta.json` regenerated (`bun run docs:type-gen`) so the API reference tables pick up the new prop. Note: the committed file was stale relative to recent popup-menu refactors (#453, #454, #466), so this also includes that catch-up churn.

## Motivation

Today the submenu always closes when the pointer leaves the trigger on a "miss" trajectory. Some UIs (hover-to-preview panels, pinned submenus) want the popup to stay put once opened. This prop only suppresses the pointer-leave close; every other close path is unchanged — highlighting a sibling item in the parent menu still closes it via `closeSiblingSubmenus`, keyboard close still works, and filtering the trigger out still closes it. Suppressing sibling-highlight close would require touching `ListboxStore` and was deliberately left out.

## Tests

New `describe('submenu closeOnPointerLeave')` in `popup-menu.test.tsx`:

- keeps the submenu open after a miss trajectory when `closeOnPointerLeave={false}`
- still closes when a sibling item in the parent menu is highlighted (asserts it was still open after the miss first, so the close is attributable to the sibling highlight)
- with `closeDelay > 0`: after an initial aim-guard hit and a reversal, the leave monitor is torn down, so a subsequent sibling highlight isn't undone by a stale monitor re-opening the submenu (fails without the `clearLeaveMonitor` gates in `startLeaveMonitor`)

Default behaviour remains covered by the existing `submenu closeDelay` tests.

Closes [UI-499](https://linear.app/bazzalabs/issue/UI-499/add-closeonpointerleave-prop-to-submenutrigger)
