### PR TITLE
docs(ship): switch stacking tool to gh-stack with Graphite migration note

### DIFF
--- a/.agents/ship.md
+++ b/.agents/ship.md
@@ -18,6 +18,12 @@ Note: this team has a `Canary` state (merged to canary branch, published as cana
 - Changesets: `bun run changeset` to add; publish scripts in root `package.json` (`ci:publish` lists packages explicitly — new publishable packages must be added there)
 - No DB/migrations in this repo (demo DB for examples lives in `apps/web` with `drizzle.config.ts` + seed script when present)
 
+## Stacking
+
+- **Tool**: `gh-stack` (GitHub CLI `gh stack` extension). Alternative value: `graphite` (`gt`).
+- **Trunk**: `canary` (all new Ship work stacks on `canary`; `main` is the stable-release trunk).
+- **Migration note**: stacks created before this switch were built with Graphite (`gt`). When resuming work on one of those stacks (a parent issue with branches already submitted), convert it to a GitHub stack before landing the next slice: `gh stack init --base canary <branch-1> <branch-2> ...` (bottom to top — `init` adopts existing branches) then `gh stack submit --auto --open` to link the existing PRs into a GitHub stack and correct their base branches. Do not run `gt` commands on it afterwards; the two tools' tracking state must not be mixed on one stack.
+
 ## Vocabulary
 
 This repo maintains a domain glossary. Presence of this section enables ship's vocabulary behaviors (see the ship skill's config gates).


### PR DESCRIPTION
## Summary

Switches this repo's Ship workflow from Graphite to GitHub's native stacked PRs by adding a `## Stacking` section to `.agents/ship.md`. The ship skill reads this section to decide which tool lands work; nothing else in the repo changes.

## Changes

- `.agents/ship.md`: new `## Stacking` section with **Tool** = `gh-stack` (GitHub CLI `gh stack` extension), **Trunk** = `canary`, and a **Migration note** describing how to convert a pre-existing Graphite stack (`gh stack init --base canary <branches…>` bottom-to-top, then `gh stack submit --auto --open`) when work on it resumes, and that `gt` must not be run on a stack after conversion.

## Motivation

The ship skill (v2.6+) is now tool-agnostic and selects the stacking tool per repo from this config section. This repo is moving its Ship-driven stacks onto GitHub's stacked PRs. Several Graphite-built stacks are still in flight (see `wt list`), so the config records the conversion recipe rather than leaving it to be rediscovered mid-execution.

This PR is itself the first `gh stack` submission in the repo, opened by the ship `quick` flow following the new config.

## Tests

No automated tests — documentation/config only. Verified `bun run check` stays green (9 pre-existing Biome warnings on `canary`, none introduced) and that the diff is limited to `.agents/ship.md`.

Closes [UI-500](https://linear.app/bazzalabs/issue/UI-500/switch-ship-stacking-tool-to-github-stacks)
