### PR TITLE
docs(popup-menu): define Root, Branch, Resolution; add ADR-0002

### DIFF
--- a/docs/adr/0002-resolve-static-content-synchronously.md
+++ b/docs/adr/0002-resolve-static-content-synchronously.md
@@ -1,0 +1,8 @@
+# Resolve static content synchronously during render; graft loader results in effects
+
+The popup-menu engine's root data list feeds node defs into the Menu Tree resolver. Resolution of the static `content` prop happens synchronously during render, keyed on the `content` array's own reference, so the first render already has Menu Nodes and no empty frame is shown. Loader results are the only defs that arrive after mount; the decision is that they are grafted from effects, never from render. The resolver's reference fast-path (`setContent`/`graft` are no-ops when handed the same array) is correct precisely because the key is the true input, not a derived array. An earlier attempt keyed resolution on arrays rebuilt every render (merged async content) and produced an infinite render loop; the fix is the keying rule, not moving all resolution into effects.
+
+## Considered Options
+
+- **Resolve everything in effects** — a clean "never mutate during render" rule, but the first render has no nodes, causing an empty frame and complicating SSR/hydration.
+- **`useSyncExternalStore` over the resolver** — the React-blessed shape for an external mutable source, but it adds a subscription layer for a store that has exactly one writer. Revisit if the resolver gains multiple writers.

--- a/packages/react/src/internal/popup-menu/CONTEXT.md
+++ b/packages/react/src/internal/popup-menu/CONTEXT.md
@@ -31,8 +31,8 @@ A node's single definition-path component: its explicit id verbatim when present
 _Avoid_: segment, slug, part
 
 **Definition Path** (`definitionPath`):
-The segments from the menu root to a node in the definition tree, including the node's own segment. Only submenu and subpage ancestors contribute segments; groups, radio groups, and tree items are surface-transparent. Identical wherever the node renders — browse, deep search, or recursion.
-_Avoid_: absolute path, tree path, full path, ancestor path
+The Definition Keys from the menu root to a node in the definition tree, including the node's own key. Only submenu and subpage ancestors contribute keys; groups, radio groups, and tree items are surface-transparent. Identical wherever the node renders — browse, deep search, or recursion.
+_Avoid_: absolute path, tree path, full path, ancestor path, segments
 
 **Breadcrumbs**:
 The branch nodes walked by the displaying surface to reach a row within its own render pass. Carries rich node references, not just segments.
@@ -49,12 +49,20 @@ _Avoid_: composite id, qualified id
 The definitional menu-node facts passed to `getResolvedId` before the resolved ID is assigned.
 
 **Graft**:
-Resolving node defs that arrive after mount (async loader results; render-time content) and attaching the resulting nodes under an already-resolved parent — the graft point — so they join the single resolved tree with correct lineage (definition path, Resolved ID).
+Resolution of node defs that arrive after mount (async loader results; render-time content) and attaching the resulting nodes under an already-resolved parent — the graft point — so they join the single resolved tree with correct lineage (definition path, Resolved ID).
 _Avoid_: merge, inject, append
 
-**Detached Node**:
-The stable placeholder node produced for a def that is rendered but is not part of the resolved tree (a consumer passing an arbitrary def to `renderNode`). Dev-warned once per def; its id is root-relative rather than path-qualified. Not a supported authoring pattern — memoize defs and prefer explicit ids.
-_Avoid_: orphan node, temp node
+**Root**:
+The menu's top-level surface — the one a popup opens with. Owns the Menu Tree but is not a Menu Node: its children are the tree's top-level nodes. Consequently it has no Resolved ID, no subpage identity, and no branch loader; the root surface's own async content is represented separately from branch loaders.
+_Avoid_: root node, root page, `__root__`
+
+**Branch**:
+A submenu or subpage Menu Node — a node that opens a child surface. Only branches can own a branch loader or a subpage. Groups, radio groups, and tree items contain nodes but are not branches; they open no surface.
+_Avoid_: container, parent (as a category), async submenu (a branch may be static)
+
+**Resolution**:
+The phase that turns node defs into Menu Nodes in the Menu Tree: static content synchronously when the content is supplied; loader results by grafting after they arrive. The only phase permitted to mutate the Menu Tree.
+_Avoid_: resolving (as a noun), reconciliation (reconcile is one operation inside resolution)
 
 **Listbox**:
 The state layer beneath the engine: rows register into a `ListboxStore`, which owns highlight state and keyboard navigation. Implements the WAI-ARIA listbox pattern; shared by every menu family.
@@ -68,3 +76,6 @@ These terms described the string-based identity model and no longer exist in the
 - **Row ID** / `getRowId` — replaced by Resolved ID / `getResolvedId`.
 - **Segment** / `pathSegment` — replaced by Definition Key / `definitionKey`.
 - **Display Path** (`displayPath`) — the segments of the submenus enclosing the surface a row was displayed in. Contextual by nature; deleted along with the strategy machinery that consumed it.
+- **Identity Scheme** — any derivation of a row, page, loader, or deduplication key that bypasses the Menu Tree and recomputes identity from defs, values, or paths. Every scheme is replaced by the Resolved ID. Removed schemes: the subpage page ID (`getSubpagePageId`, `SubpageDef.pageId`), the async loader key (`getAsyncLoaderIdForBranch`), the deep-search dedup composite key, and the `__root__` sentinel (`ROOT_SUBPAGE_ID`).
+- **Detached Node** — the placeholder produced when an out-of-tree def was passed to `renderNode`. Render callbacks now receive only Menu Nodes; the case is inexpressible.
+- **Publication** — a token/withdrawal handoff of resolved nodes between a root list and sibling subpages, prototyped in an abandoned branch. Never entered the glossary; recorded so the name is not reused.


### PR DESCRIPTION
## Summary

Docs-only first slice of the popup-menu resolved-identity stack: defines three glossary terms (**Root**, **Branch**, **Resolution**) in the Popup Menu context, records the identity schemes this stack deletes under *Removed vocabulary*, and adds ADR-0002 on when the engine resolves content. No source files change.

## Changes

- `packages/react/src/internal/popup-menu/CONTEXT.md`
  - New entries **Root**, **Branch**, **Resolution** (inserted after **Graft**).
  - **Definition Path** definition now speaks of Definition Keys instead of the removed word "segment"; `segments` added to its *Avoid* list.
  - **Graft** definition reworded to start "Resolution of…" (its *Avoid* list forbids "resolving" as a noun).
  - **Detached Node** moved out of `## Language` into `## Removed vocabulary`, alongside new bullets for **Identity Scheme** and **Publication**.
- `docs/adr/0002-resolve-static-content-synchronously.md` (new): static `content` is resolved synchronously during render keyed on the array reference; loader results are grafted from effects. Records the render-loop root cause of the previous attempt and the considered alternatives.

## Motivation

Every later slice in this stack cites these terms instead of re-explaining them: slice 2 renames the pipeline directory, slices 4–5 build the resolution phase and walk Menu Nodes in the display pipeline, and slices 6–8 delete the four parallel identity schemes named under **Identity Scheme**. The *Removed vocabulary* entries deliberately land *before* the code they describe is deleted — they record the decision so the names are not reintroduced with new meanings.

ADR-0002 exists because the prior attempt at this refactor (closed PR #462) produced an infinite render loop by keying resolution on arrays rebuilt every render. The fix is the keying rule, not moving all resolution into effects; the ADR pins that so the resolution slice does not relitigate it.

## Tests

No automated tests — documentation only. Verified: `bun run check` exits 0; `git diff --stat canary` touches only the two in-scope files; `rg -c "^\*\*" packages/react/src/internal/popup-menu/CONTEXT.md` → 15 (13 at base: three entries added, one moved to a bullet); `CONTEXT-MAP.md`, `packages/react/CONTEXT.md`, and ADR-0001 are byte-identical.

Closes [UI-502](https://linear.app/bazzalabs/issue/UI-502/define-root-branch-resolution-add-adr-0002)
