### PR TITLE
fix(popup-menu): `reconcile` returns the existing array when nothing changed

### DIFF
--- a/.changeset/reconcile-stable-arrays.md
+++ b/.changeset/reconcile-stable-arrays.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': patch
+---
+
+The popup-menu Menu Tree resolver now returns the existing node array from `setContent`/`graft` when re-supplied defs produce no change, so `rootNodes` and `parent.children` keep their identity across unchanged re-renders.

--- a/packages/react/src/internal/popup-menu/menu-tree/__tests__/resolver.test.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/__tests__/resolver.test.ts
@@ -279,6 +279,71 @@ describe('createMenuTreeResolver', () => {
     expect(groupNode.children[1]!.definitionPath).toEqual(['status', 'late'])
     expect(groupNode.children[1]!.id).toBe('status/late')
   })
+
+  it('returns the same rootNodes array when re-supplied a fresh array of the same defs', () => {
+    const a = item('A')
+    const b = item('B')
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([a, b])
+    const first = resolver.rootNodes
+
+    resolver.setContent([a, b])
+
+    expect(resolver.rootNodes).toBe(first)
+  })
+
+  it('returns the same children array on graft when nothing changed', () => {
+    const child = item('Child')
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([submenu('Parent', [child])])
+    const node = resolver.rootNodes[0]!
+    resolver.graft(node, [child])
+    const kids = node.children
+
+    resolver.graft(node, [child])
+
+    expect(node.children).toBe(kids)
+  })
+
+  it('returns a new array when order changes', () => {
+    const a = item('A')
+    const b = item('B')
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([a, b])
+    const first = resolver.rootNodes
+
+    resolver.setContent([b, a])
+
+    expect(resolver.rootNodes).not.toBe(first)
+    expect(resolver.rootNodes.map((node) => node.def)).toEqual([b, a])
+  })
+
+  it('returns a new array when a def is swapped for an equivalent one', () => {
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([item('A')])
+    const first = resolver.rootNodes
+    const node = first[0]
+
+    resolver.setContent([item('A')])
+
+    expect(resolver.rootNodes).not.toBe(first)
+    expect(resolver.rootNodes[0]).toBe(node)
+  })
+
+  it('returns a new array when a node is added or removed', () => {
+    const a = item('A')
+    const b = item('B')
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([a])
+    const first = resolver.rootNodes
+
+    resolver.setContent([a, b])
+    const second = resolver.rootNodes
+    resolver.setContent([a])
+
+    expect(second).not.toBe(first)
+    expect(resolver.rootNodes).not.toBe(second)
+  })
 })
 
 describe('duplicate detection', () => {

--- a/packages/react/src/internal/popup-menu/menu-tree/resolver.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/resolver.ts
@@ -231,11 +231,15 @@ export function createMenuTreeResolver(
       } else matches.push(undefined)
     }
 
+    let unchanged = existing.length === defs.length
     for (const node of existing) {
-      if (!matched.has(node)) retire(node)
+      if (!matched.has(node)) {
+        unchanged = false
+        retire(node)
+      }
     }
 
-    return defs.map((def, index) => {
+    const result = defs.map((def, index) => {
       const node = matches[index]
       const { definitionKey, definitionPath, id } = prospectiveIdentity(
         def,
@@ -246,6 +250,7 @@ export function createMenuTreeResolver(
       )
 
       if (!node) {
+        unchanged = false
         const created = resolveNodeDefs(
           [def],
           parent,
@@ -265,10 +270,12 @@ export function createMenuTreeResolver(
       }
 
       if (node.def === def && samePath(node.definitionPath, definitionPath)) {
+        if (existing[index] !== node || node.index !== index) unchanged = false
         node.index = index
         return node
       }
 
+      unchanged = false
       if (defToNode.get(node.def) === node) defToNode.delete(node.def)
       const oldScope = scopeOf(node)
       const oldHoldersByKey = keyHolders.get(oldScope)
@@ -302,6 +309,7 @@ export function createMenuTreeResolver(
       register(node, scopeOf(node))
       return node
     })
+    return unchanged ? existing : result
   }
 
   return {


### PR DESCRIPTION
## Summary

The Menu Tree resolver's `reconcile` now returns the **existing** node array when a fresh def array produces no structural change, so `rootNodes` and `parent.children` keep their identity across unchanged re-renders. Node reuse, def swaps, retirement, and recursive child reconciliation are untouched — only the return value changes, and only in the no-op case.

## Changes

- `packages/react/src/internal/popup-menu/menu-tree/resolver.ts` — `reconcile` tracks an `unchanged` flag: seeded by `existing.length === defs.length`, cleared on any retirement, node creation, def/path swap, reorder (`existing[index] !== node`), or stale `node.index`. The `defs.map` still runs in full so every per-node side effect (register/retire/index/def bookkeeping) is identical to before; the function ends with `return unchanged ? existing : result`.
- `menu-tree/__tests__/resolver.test.ts` — five identity tests: same array on no-op `setContent` and no-op `graft`; new array on reorder, on equivalent-def swap (node instance still reused), and on add/remove.
- `.changeset/reconcile-stable-arrays.md` — patch changeset.

## Motivation

Builds on #471. Today `setContent`/`graft` allocate a new array on every non-reference-equal call even when nothing changed, which forces every React memo keyed on `rootNodes` / `parent.children` to recompute. The next slice in [UI-501](https://linear.app/bazzalabs/issue/UI-501) extracts the resolution phase and keys static resolution on the `content` array's reference (see ADR-0002 in #470); it depends on array identity being stable *iff* content is unchanged, which this PR guarantees. The reference fast path (`defs === lastRootDefs` / `lastGraftDefs`) is kept — the structural short-circuit is in addition to it.

## Tests

Five new cases in `resolver.test.ts` (58 in the `menu-tree` scope, up from 53). Verified the two "same array" tests fail against the pre-change `resolver.ts` and pass with it. Full package suite: 40 files / 907 tests green; `bun run check`, `type-check`, and `build` exit 0.

Closes [UI-504](https://linear.app/bazzalabs/issue/UI-504/reconcile-returns-the-existing-array-when-nothing-changed)
