### PR TITLE
refactor(popup-menu)!: render callbacks receive Menu Nodes only

### DIFF
--- a/.changeset/render-callbacks-menu-nodes.md
+++ b/.changeset/render-callbacks-menu-nodes.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': minor
+---
+
+**Breaking change.** Data-first submenu and subpage render callbacks now receive resolved Menu Nodes: `nodes` is `PopupMenuNode[]` and `renderNode` accepts a `PopupMenuNode` only. Read authored fields via `child.def` (`child.value` → `child.def.value`). Passing a raw node def to `renderNode` is no longer supported; `DataSurface.content` still accepts either defs or Menu Nodes.

--- a/packages/react/src/command-menu/command-menu-async.test.tsx
+++ b/packages/react/src/command-menu/command-menu-async.test.tsx
@@ -8,6 +8,7 @@ import {
   type DeepSearchConfig,
   type LoaderComponentProps,
   type NodeDef,
+  type PopupMenuNode,
   type SubpageDef,
   useDataList,
 } from './index.js'
@@ -652,7 +653,7 @@ describe('CommandMenu async data-first API', () => {
     expect(screen.getByTestId('item-beta')).toBeInTheDocument()
   })
 
-  it('renders a subpage whose loader replaces its static children without crashing', async () => {
+  it('hands a subpage callback only static children, even after its loader replaces them', async () => {
     const user = userEvent.setup()
     const loader = createControllableLoader()
     const staticProject = createItemDef('static-project', 'Static project')
@@ -666,35 +667,40 @@ describe('CommandMenu async data-first API', () => {
         loadStrategy: 'lazy',
       },
     })
-    // Hand the authored static def straight back through `renderNode`, the
-    // way a custom `renderContent` may.
-    subpage.renderContent = ({ pageId, asyncContent, renderNode }) => (
-      <>
-        <CommandMenu.Subpage pageId={pageId}>
-          <CommandMenu.Surface
-            asyncContent={asyncContent}
-            content={[staticProject]}
-            data-testid="surface-projects"
-          >
-            <CommandMenu.Input
-              aria-label="Search Projects"
-              data-testid="input-projects"
-            />
-            <CommandMenu.List data-testid="list-projects">
-              <CommandMenu.SubpageBackItem
-                data-testid="subpage-back-projects"
-                value="projects-back"
-              >
-                Back
-              </CommandMenu.SubpageBackItem>
-              {renderNode(staticProject)}
-              <DataRows />
-            </CommandMenu.List>
-          </CommandMenu.Surface>
-        </CommandMenu.Subpage>
-        <SubpageContentReady id="projects" />
-      </>
-    )
+    // Render the callback's `nodes` directly (as a custom `renderContent`
+    // may) in addition to the surface's own rows, and record what it was
+    // handed on every render.
+    const seenNodes: PopupMenuNode[][] = []
+    subpage.renderContent = ({ pageId, asyncContent, nodes, renderNode }) => {
+      seenNodes.push(nodes)
+      return (
+        <>
+          <CommandMenu.Subpage pageId={pageId}>
+            <CommandMenu.Surface
+              asyncContent={asyncContent}
+              content={nodes}
+              data-testid="surface-projects"
+            >
+              <CommandMenu.Input
+                aria-label="Search Projects"
+                data-testid="input-projects"
+              />
+              <CommandMenu.List data-testid="list-projects">
+                <CommandMenu.SubpageBackItem
+                  data-testid="subpage-back-projects"
+                  value="projects-back"
+                >
+                  Back
+                </CommandMenu.SubpageBackItem>
+                {nodes.map(renderNode)}
+                <DataRows />
+              </CommandMenu.List>
+            </CommandMenu.Surface>
+          </CommandMenu.Subpage>
+          <SubpageContentReady id="projects" />
+        </>
+      )
+    }
     const nodes: NodeDef[] = [subpage]
 
     render(
@@ -712,16 +718,23 @@ describe('CommandMenu async data-first API', () => {
     await waitForSubpageInputFocus('projects')
     // Once via `DataRows`, once via the direct `renderNode` call.
     expect(screen.getAllByTestId('item-static-project')).toHaveLength(2)
+    expect(seenNodes.at(-1)?.map((n) => n.def)).toEqual([staticProject])
 
-    // `asyncContent` replaces the static children under the subpage branch;
-    // the authored static def handed back through `renderNode` must render
-    // nothing rather than throw.
+    // `asyncContent` replaces the static children under the subpage branch:
+    // the callback's `nodes` never contains loader results, and is empty once
+    // the static children have left the tree.
     await resolveLoader(loader, [
       createItemDef('loaded-project', 'Loaded project'),
     ])
     await waitFor(() => {
       expect(screen.getByTestId('item-loaded-project')).toBeInTheDocument()
+      expect(
+        screen.queryByTestId('item-static-project'),
+      ).not.toBeInTheDocument()
     })
-    expect(screen.queryByTestId('item-static-project')).not.toBeInTheDocument()
+    for (const seen of seenNodes) {
+      expect(seen.every((n) => n.def === staticProject)).toBe(true)
+    }
+    expect(seenNodes.at(-1)).toEqual([])
   })
 })

--- a/packages/react/src/internal/popup-menu/CONTEXT.md
+++ b/packages/react/src/internal/popup-menu/CONTEXT.md
@@ -17,6 +17,7 @@ _Avoid_: node config, definition object
 **Menu Node**:
 The library-created, resolved instance of a node def — carries identity (resolved ID, definition key, definition path), tree links (parent, children), and a reference to its originating def. Exactly one per logical row per menu root, in every render context; created by resolution at the root, or by grafting. Surfaced to consumers as `Node` under each family namespace.
 _Avoid_: resolved node (as a noun — "resolution" stays as the process), wrapper, instance
+Submenu and subpage render callbacks receive only resolver-owned child Menu Nodes as `nodes`; authored fields are available through `child.def`.
 
 **Menu Tree**:
 The single resolved node tree owned by one menu root, and the `MenuTreeResolver` that maintains it. Created once per root; re-supplied content reconciles into it rather than rebuilding it.

--- a/packages/react/src/internal/popup-menu/data-first/__tests__/data-list.test.tsx
+++ b/packages/react/src/internal/popup-menu/data-first/__tests__/data-list.test.tsx
@@ -82,7 +82,7 @@ function createTestSubmenuDef(
     id,
     value,
     nodes,
-    render: ({ props, context, renderNode }) => (
+    render: ({ props, context, nodes: resolvedNodes, renderNode }) => (
       <DropdownMenu.Submenu>
         <DropdownMenu.SubmenuTrigger
           {...props}
@@ -95,7 +95,9 @@ function createTestSubmenuDef(
           <DropdownMenu.Positioner>
             <DropdownMenu.Popup>
               <DropdownMenu.Surface>
-                <DropdownMenu.List>{nodes.map(renderNode)}</DropdownMenu.List>
+                <DropdownMenu.List>
+                  {resolvedNodes.map(renderNode)}
+                </DropdownMenu.List>
               </DropdownMenu.Surface>
             </DropdownMenu.Popup>
           </DropdownMenu.Positioner>
@@ -1319,7 +1321,7 @@ describe('resolved render params', () => {
     )
   })
 
-  it('passes definition paths and unwraps resolved renderNode arguments', async () => {
+  it('passes definition paths and resolved renderNode arguments', async () => {
     const child = createTestItemDef('path-child', 'Child', {
       render: ({ props, node }) => (
         <DropdownMenu.Item {...props} data-testid="path-child">
@@ -1328,39 +1330,73 @@ describe('resolved render params', () => {
       ),
     })
     const submenu = createTestSubmenuDef('parent', 'Parent', [child], {
-      render: ({ props, node, renderNode }) => (
-        <DropdownMenu.Submenu>
-          <DropdownMenu.SubmenuTrigger {...props} />
-          <DropdownMenu.Portal>
-            <DropdownMenu.Positioner>
-              <DropdownMenu.Popup>
-                <DropdownMenu.Surface>
-                  <DropdownMenu.List>
-                    {renderNode(node.children[0])}
-                    {renderNode(node.children[0].def)}
-                  </DropdownMenu.List>
-                </DropdownMenu.Surface>
-              </DropdownMenu.Popup>
-            </DropdownMenu.Positioner>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Submenu>
-      ),
+      render: ({ props, node, nodes, renderNode }) => {
+        expect(nodes[0]).toBe(node.children[0])
+        return (
+          <DropdownMenu.Submenu>
+            <DropdownMenu.SubmenuTrigger {...props} />
+            <DropdownMenu.Portal>
+              <DropdownMenu.Positioner>
+                <DropdownMenu.Popup>
+                  <DropdownMenu.Surface>
+                    <DropdownMenu.List>
+                      {renderNode(node.children[0])}
+                    </DropdownMenu.List>
+                  </DropdownMenu.Surface>
+                </DropdownMenu.Popup>
+              </DropdownMenu.Positioner>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Submenu>
+        )
+      },
     })
     const user = userEvent.setup()
     render(<MenuWithDataContent content={[submenu]} />)
     await user.hover(screen.getByRole('menuitem'))
     await waitFor(() => {
       const childRows = screen.getAllByTestId('path-child')
-      expect(childRows).toHaveLength(2)
-      expect(childRows.map((row) => row.id)).toEqual([
-        'parent/child',
-        'parent/child',
-      ])
+      expect(childRows).toHaveLength(1)
+      expect(childRows.map((row) => row.id)).toEqual(['parent/child'])
       expect(
         childRows.map(
           (row) => row.querySelector('[data-testid="child-path"]')?.textContent,
         ),
-      ).toEqual(['parent/child', 'parent/child'])
+      ).toEqual(['parent/child'])
+    })
+  })
+
+  it('callback nodes are resolved children with lineage', async () => {
+    const child1Def = createTestItemDef('first', 'First')
+    const child2Def = createTestItemDef('second', 'Second')
+    let callbackNodes: PopupMenuNode[] | undefined
+    let parentNode: PopupMenuNode | undefined
+    const submenu = createTestSubmenuDef(
+      'lineage-parent',
+      'Parent',
+      [child1Def, child2Def],
+      {
+        render: ({ props, node, nodes }) => {
+          callbackNodes = nodes
+          parentNode = node
+          return (
+            <DropdownMenu.Submenu>
+              <DropdownMenu.SubmenuTrigger {...props} />
+            </DropdownMenu.Submenu>
+          )
+        },
+      },
+    )
+    const user = userEvent.setup()
+    render(<MenuWithDataContent content={[submenu]} />)
+    await user.hover(screen.getByRole('menuitem'))
+    await waitFor(() => {
+      expect(callbackNodes).toHaveLength(2)
+      expect(callbackNodes?.[0].parent).toBe(parentNode)
+      expect(callbackNodes?.[0].def).toBe(child1Def)
+      expect(callbackNodes?.[0].definitionPath).toEqual([
+        ...parentNode.definitionPath,
+        callbackNodes?.[0].definitionKey,
+      ])
     })
   })
 })

--- a/packages/react/src/internal/popup-menu/data-first/data-list.tsx
+++ b/packages/react/src/internal/popup-menu/data-first/data-list.tsx
@@ -18,7 +18,7 @@ import { useMenuTreeResolver } from '../contexts/menu-tree-resolver-context.js'
 import { useMaybeSubpageContext } from '../contexts/subpage-context.js'
 import { useMaybeSubpageStack } from '../contexts/subpage-stack-context.js'
 import { useResolution } from '../hooks/use-resolution.js'
-import { isPopupMenuNode } from '../menu-tree/resolve.js'
+import { staticChildrenOf } from '../menu-tree/resolve.js'
 import type { PopupMenuNode } from '../menu-tree/types.js'
 import {
   type AsyncMenuState,
@@ -899,7 +899,7 @@ export const DataListInner = React.forwardRef<
         const submenuAsyncState = getBranchAsyncState(node)
 
         // Static nodes only - async content is handled by the submenu's own DataSurface
-        const staticNodes = node.nodes ?? []
+        const staticChildren = staticChildrenOf(resolved)
 
         // Create breadcrumb node for current submenu (used in child contexts)
         const submenuBreadcrumb: BreadcrumbNode = {
@@ -909,23 +909,9 @@ export const DataListInner = React.forwardRef<
           id: node.id,
         }
 
-        // Children of this submenu are Menu Nodes under `resolved`; a def
-        // handed to `renderNode` is matched back to its Menu Node there.
-        const childMenuNodeFor = <D extends NodeDef>(
-          def: D,
-        ): PopupMenuNode<D> | undefined =>
-          resolved.children.find((child) => child.def === def) as
-            | PopupMenuNode<D>
-            | undefined
-
-        const submenuRenderNode = (
-          arg: NodeDef | PopupMenuNode,
-        ): React.ReactNode => {
-          const childMenuNode = isPopupMenuNode(arg)
-            ? arg
-            : childMenuNodeFor(arg)
-          if (!childMenuNode) return null
-          const childNode = childMenuNode.def
+        const submenuRenderNode = (arg: PopupMenuNode): React.ReactNode => {
+          const childMenuNode = arg
+          const childNode = arg.def
           // Skip separators
           if (childNode.kind === 'separator') {
             return null
@@ -1059,7 +1045,7 @@ export const DataListInner = React.forwardRef<
                   disabled: node.disabled ?? false,
                   async: submenuAsyncState,
                 },
-                nodes: staticNodes,
+                nodes: staticChildren,
                 asyncContent: node.asyncNodes,
                 renderNode: submenuRenderNode,
               })}

--- a/packages/react/src/internal/popup-menu/data-first/data-subpages.tsx
+++ b/packages/react/src/internal/popup-menu/data-first/data-subpages.tsx
@@ -2,10 +2,11 @@
 
 import * as React from 'react'
 import { GraftPointContext } from '../contexts/graft-point-context.js'
-import { isPopupMenuNode } from '../menu-tree/resolve.js'
+import { staticChildrenOf } from '../menu-tree/resolve.js'
 import type { PopupMenuNode } from '../menu-tree/types.js'
 import { useAsyncMenuCoordinator } from './async-coordinator.js'
 import { useDataPopupContext } from './context.js'
+import { isRowMenuNode } from './type-guards.js'
 import type {
   AsyncRenderState,
   BreadcrumbNode,
@@ -13,12 +14,12 @@ import type {
   DataSubpagesChildrenState,
   DataSubpagesProps,
   DisplaySubpageNode,
+  GroupDef,
   GroupRenderContext,
   ItemDef,
-  NodeDef,
   QueryLoaderConfig,
   RadioGroupDef,
-  RadioItemDef,
+  RowNodeDef,
   RowRenderContext,
   SubmenuDef,
   SubpageDef,
@@ -216,24 +217,6 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
   const searchQuery = coordinator?.searchQuery ?? ''
 
   const { dataSurfaceContext, resolvedNodes } = useDataPopupContext()
-  // Every def rendered inside a subpage is a descendant of that subpage's Menu
-  // Node (static children, grafted loader results, or nested branches). One
-  // def → Menu Node index per subpage render lets render callbacks hand back
-  // defs (the public `renderNode` contract) without a per-row walk.
-  const indexMenuNodesUnder = React.useCallback(
-    (root: PopupMenuNode): WeakMap<NodeDef, PopupMenuNode> => {
-      const index = new WeakMap<NodeDef, PopupMenuNode>()
-      const stack: PopupMenuNode[] = [...root.children]
-      while (stack.length) {
-        const node = stack.pop()!
-        index.set(node.def, node)
-        stack.push(...node.children)
-      }
-      return index
-    },
-    [],
-  )
-
   // A retained slot is only valid while the root surface still supplies the
   // content it was published for (the root list unmounts while a subpage is
   // active, so it cannot republish on its own).
@@ -261,27 +244,11 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
         value: node.value,
         id: node.id,
       }
-      // A def that is not in this subpage's Menu Tree (e.g. an authored static
-      // child after the subpage's own loader replaced the content, or a def
-      // re-created between renders) renders nothing — the same rule the
-      // submenu path applies.
-      const menuNodeIndex = indexMenuNodesUnder(resolved)
-      const menuNodeFor = <D extends NodeDef>(
-        def: D,
-      ): PopupMenuNode<D> | undefined =>
-        menuNodeIndex.get(def) as PopupMenuNode<D> | undefined
-
       const renderRowNode = (
-        rowNode:
-          | ItemDef
-          | RadioItemDef
-          | CheckboxItemDef
-          | SubmenuDef
-          | SubpageDef,
+        rowMenuNode: PopupMenuNode<RowNodeDef>,
         rowContext: RowRenderContext,
       ): React.ReactNode => {
-        const rowMenuNode = menuNodeFor(rowNode)
-        if (!rowMenuNode) return null
+        const rowNode = rowMenuNode.def
         const rowId = rowMenuNode.id
 
         if (rowNode.kind === 'item') {
@@ -361,7 +328,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
             searchQuery,
             coordinator,
           )
-          const staticNodes = rowNode.nodes ?? []
+          const staticChildren = staticChildrenOf(rowMenuNode)
           const submenuBreadcrumb: BreadcrumbNode = {
             node: rowNode,
             menuNode: rowMenuNode as PopupMenuNode<SubmenuDef>,
@@ -369,20 +336,24 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
             id: rowNode.id,
           }
 
-          const submenuRenderNode = (arg: NodeDef | PopupMenuNode) => {
-            const childNode = isPopupMenuNode(arg) ? arg.def : arg
+          const submenuRenderNode = (arg: PopupMenuNode) => {
+            const childNode = arg.def
             if (childNode.kind === 'separator') {
               return null
             }
 
             if (childNode.kind === 'group') {
-              const groupItems = childNode.nodes.filter(
-                (n): n is ItemDef | CheckboxItemDef | SubmenuDef | SubpageDef =>
-                  (n.kind === 'item' ||
-                    n.kind === 'checkbox-item' ||
-                    n.kind === 'submenu' ||
-                    n.kind === 'subpage') &&
-                  !n.hidden,
+              const groupItems = arg.children.filter(
+                (
+                  n,
+                ): n is PopupMenuNode<
+                  ItemDef | CheckboxItemDef | SubmenuDef | SubpageDef
+                > =>
+                  (n.def.kind === 'item' ||
+                    n.def.kind === 'checkbox-item' ||
+                    n.def.kind === 'submenu' ||
+                    n.def.kind === 'subpage') &&
+                  !n.def.hidden,
               )
 
               if (groupItems.length === 0) {
@@ -395,7 +366,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                   breadcrumbs: [...rowContext.breadcrumbs, submenuBreadcrumb],
                   isDeepSearchResult: false,
                   highlighted: false,
-                  disabled: item.disabled ?? false,
+                  disabled: item.def.disabled ?? false,
                   group: { id: childNode.id, label: childNode.label },
                   tree: null,
                 }),
@@ -409,8 +380,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                   isDeepSearchResult: false,
                 }
 
-                const groupMenuNode = menuNodeFor(childNode)
-                if (!groupMenuNode) return null
+                const groupMenuNode = arg as PopupMenuNode<GroupDef>
                 return (
                   <React.Fragment key={childNode.id}>
                     {childNode.render({
@@ -439,7 +409,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
             }
 
             if (childNode.kind === 'radio-group') {
-              return renderRadioGroup(childNode, [
+              return renderRadioGroup(arg as PopupMenuNode<RadioGroupDef>, [
                 ...rowContext.breadcrumbs,
                 submenuBreadcrumb,
               ])
@@ -454,15 +424,20 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
               return null
             }
 
-            return renderRowNode(childNode, {
-              search: null,
-              breadcrumbs: [...rowContext.breadcrumbs, submenuBreadcrumb],
-              isDeepSearchResult: false,
-              highlighted: false,
-              disabled: childNode.disabled ?? false,
-              group: null,
-              tree: null,
-            })
+            return renderRowNode(
+              arg as PopupMenuNode<
+                ItemDef | CheckboxItemDef | SubmenuDef | SubpageDef
+              >,
+              {
+                search: null,
+                breadcrumbs: [...rowContext.breadcrumbs, submenuBreadcrumb],
+                isDeepSearchResult: false,
+                highlighted: false,
+                disabled: childNode.disabled ?? false,
+                group: null,
+                tree: null,
+              },
+            )
           }
 
           return (
@@ -480,13 +455,15 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                   disabled: rowNode.disabled ?? false,
                   async: submenuAsyncState,
                 },
-                nodes: staticNodes,
+                nodes: staticChildren,
                 asyncContent: rowNode.asyncNodes,
                 renderNode: submenuRenderNode,
               })}
             </React.Fragment>
           )
         }
+
+        if (rowNode.kind !== 'subpage') return null
 
         const subpageAsyncState = getBranchAsyncState(
           rowNode,
@@ -518,9 +495,10 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
       }
 
       const renderRadioGroup = (
-        radioGroup: RadioGroupDef,
+        radioGroupMenuNode: PopupMenuNode<RadioGroupDef>,
         breadcrumbs: BreadcrumbNode[] = [],
       ): React.ReactNode => {
+        const radioGroup = radioGroupMenuNode.def
         const isDeepSearchResult = breadcrumbs.length > 0
 
         const groupContext: GroupRenderContext = {
@@ -530,22 +508,20 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
           isDeepSearchResult,
         }
 
-        const childElements = radioGroup.nodes.map((item) => {
-          if (item.hidden) return null
+        const childElements = radioGroupMenuNode.children.map((item) => {
+          if (!isRowMenuNode(item) || item.def.hidden) return null
 
           return renderRowNode(item, {
             search: null,
             breadcrumbs,
             isDeepSearchResult,
             highlighted: false,
-            disabled: item.disabled ?? false,
+            disabled: item.def.disabled ?? false,
             group: null,
             tree: null,
           })
         })
 
-        const radioGroupMenuNode = menuNodeFor(radioGroup)
-        if (!radioGroupMenuNode) return null
         if (radioGroup.render) {
           return (
             <React.Fragment key={radioGroup.id}>
@@ -596,28 +572,26 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                   coordinator,
                 ),
               },
-              nodes: node.nodes ?? [],
+              nodes: staticChildrenOf(resolved),
               asyncContent: node.asyncNodes,
-              renderNode: (arg) => {
-                const childNode = isPopupMenuNode(arg) ? arg.def : arg
+              renderNode: (arg: PopupMenuNode) => {
+                const childNode = arg.def
                 if (childNode.kind === 'separator') {
                   return null
                 }
 
                 if (childNode.kind === 'group') {
-                  const groupItems = childNode.nodes.filter(
+                  const groupItems = arg.children.filter(
                     (
                       n,
-                    ): n is
-                      | ItemDef
-                      | CheckboxItemDef
-                      | SubmenuDef
-                      | SubpageDef =>
-                      (n.kind === 'item' ||
-                        n.kind === 'checkbox-item' ||
-                        n.kind === 'submenu' ||
-                        n.kind === 'subpage') &&
-                      !n.hidden,
+                    ): n is PopupMenuNode<
+                      ItemDef | CheckboxItemDef | SubmenuDef | SubpageDef
+                    > =>
+                      (n.def.kind === 'item' ||
+                        n.def.kind === 'checkbox-item' ||
+                        n.def.kind === 'submenu' ||
+                        n.def.kind === 'subpage') &&
+                      !n.def.hidden,
                   )
 
                   if (groupItems.length === 0) {
@@ -630,7 +604,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                       breadcrumbs: [...context.breadcrumbs, subpageBreadcrumb],
                       isDeepSearchResult: false,
                       highlighted: false,
-                      disabled: item.disabled ?? false,
+                      disabled: item.def.disabled ?? false,
                       group: { id: childNode.id, label: childNode.label },
                       tree: null,
                     }),
@@ -644,8 +618,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                       isDeepSearchResult: false,
                     }
 
-                    const groupMenuNode = menuNodeFor(childNode)
-                    if (!groupMenuNode) return null
+                    const groupMenuNode = arg as PopupMenuNode<GroupDef>
                     return (
                       <React.Fragment key={childNode.id}>
                         {childNode.render({
@@ -674,7 +647,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                 }
 
                 if (childNode.kind === 'radio-group') {
-                  return renderRadioGroup(childNode, [
+                  return renderRadioGroup(arg as PopupMenuNode<RadioGroupDef>, [
                     ...context.breadcrumbs,
                     subpageBreadcrumb,
                   ])
@@ -689,22 +662,27 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                   return null
                 }
 
-                return renderRowNode(childNode, {
-                  search: null,
-                  breadcrumbs: [...context.breadcrumbs, subpageBreadcrumb],
-                  isDeepSearchResult: false,
-                  highlighted: false,
-                  disabled: childNode.disabled ?? false,
-                  group: null,
-                  tree: null,
-                })
+                return renderRowNode(
+                  arg as PopupMenuNode<
+                    ItemDef | CheckboxItemDef | SubmenuDef | SubpageDef
+                  >,
+                  {
+                    search: null,
+                    breadcrumbs: [...context.breadcrumbs, subpageBreadcrumb],
+                    isDeepSearchResult: false,
+                    highlighted: false,
+                    disabled: childNode.disabled ?? false,
+                    group: null,
+                    tree: null,
+                  },
+                )
               },
             })}
           </GraftPointContext.Provider>
         </React.Fragment>
       )
     },
-    [coordinator, searchQuery, indexMenuNodesUnder],
+    [coordinator, searchQuery],
   )
 
   if (!dataSurfaceContext) {

--- a/packages/react/src/internal/popup-menu/data-first/types.ts
+++ b/packages/react/src/internal/popup-menu/data-first/types.ts
@@ -492,23 +492,16 @@ export interface SubmenuRenderParams {
     /** Async loading state (if asyncNodes configured) */
     async?: AsyncRenderState
   }
-  /**
-   * The submenu's static child node definitions.
-   * Does NOT include async results - use `asyncContent` for that.
-   */
-  nodes: NodeDef[]
+  /** The branch's resolved static child Menu Nodes, in def order. Loader results are grafted as children of `node` but are not included here — use `asyncContent` to load them. Authored fields are on `child.def`. */
+  nodes: PopupMenuNode[]
   /**
    * Async content configuration for this submenu.
    * Pass this to the submenu's DataSurface to enable async loading
    * with the submenu's own search query (independent of parent search).
    */
   asyncContent?: AsyncNodesConfig
-  /**
-   * Function to render a child node.
-   * Call this for each node in the submenu's list.
-   */
-  /** Resolved nodes are unwrapped to their defs. */
-  renderNode: (node: NodeDef | PopupMenuNode) => React.ReactNode
+  /** Render one child Menu Node from `nodes`. */
+  renderNode: (node: PopupMenuNode) => React.ReactNode
 }
 
 // ============================================================================
@@ -571,23 +564,16 @@ export interface SubpageContentRenderParams {
     /** Async loading state (if asyncNodes configured) */
     async?: AsyncRenderState
   }
-  /**
-   * The subpage's static child node definitions.
-   * Does NOT include async results - use `asyncContent` for that.
-   */
-  nodes: NodeDef[]
+  /** The branch's resolved static child Menu Nodes, in def order. Loader results are grafted as children of `node` but are not included here — use `asyncContent` to load them. Authored fields are on `child.def`. */
+  nodes: PopupMenuNode[]
   /**
    * Async content configuration for this subpage.
    * Pass this to the subpage's DataSurface to enable async loading
    * with the subpage's own search query (independent of parent search).
    */
   asyncContent?: AsyncNodesConfig
-  /**
-   * Function to render a child node.
-   * Call this for each node in the subpage's list.
-   */
-  /** Resolved nodes are unwrapped to their defs. */
-  renderNode: (node: NodeDef | PopupMenuNode) => React.ReactNode
+  /** Render one child Menu Node from `nodes`. */
+  renderNode: (node: PopupMenuNode) => React.ReactNode
 }
 
 // ============================================================================

--- a/packages/react/src/internal/popup-menu/menu-tree/resolve.ts
+++ b/packages/react/src/internal/popup-menu/menu-tree/resolve.ts
@@ -121,3 +121,16 @@ export function resolveNodeDefs(
     return node
   })
 }
+
+/**
+ * The branch's resolved static children: the Menu Nodes whose def is one of
+ * the branch def's authored `nodes`, in `children` order. Loader results are
+ * grafted as children too but are never in `def.nodes`, so they are excluded
+ * whether the graft appended to or replaced the static children.
+ */
+export function staticChildrenOf(branch: PopupMenuNode): PopupMenuNode[] {
+  const authored = (branch.def as { nodes?: readonly NodeDef[] }).nodes
+  if (!authored || authored.length === 0) return []
+  const authoredSet = new Set<NodeDef>(authored)
+  return branch.children.filter((child) => authoredSet.has(child.def))
+}


### PR DESCRIPTION
## Summary

Submenu and subpage render callbacks now hand consumers **Menu Nodes only**: `SubmenuRenderParams.nodes` / `SubpageContentRenderParams.nodes` are `PopupMenuNode[]`, and both `renderNode` callbacks accept a `PopupMenuNode`. The raw-def path (which used to create a Detached Node with unreliable identity) is removed at the type level and in the implementations.

## Changes

- `data-first/types.ts` — `nodes: PopupMenuNode[]` (mutable, so `content={nodes}` keeps compiling) and `renderNode: (node: PopupMenuNode) => ReactNode` on both callback param interfaces, with new JSDoc.
- `menu-tree/resolve.ts` — new `staticChildrenOf(branch)`: the branch's children whose def is one of `branch.def.nodes` by reference, in `children` order. This is what callbacks receive as `nodes`. It excludes loader results whether the graft appended to or *replaced* the static children (a subpage's own `asyncContent` replaces), which a positional prefix would get wrong.
- `data-list.tsx` — submenu callback passes `staticChildrenOf(resolved)`; `renderNode` takes `arg.def` / `arg.children` directly; the def→Menu-Node lookup helper is deleted.
- `data-subpages.tsx` — same at both callback sites; `renderRowNode` and `renderRadioGroup` take the Menu Node they were handed (no re-lookup through a def index, so a def reused twice renders each occurrence's own node); the per-subpage def index is deleted.
- `CONTEXT.md` — one sentence on the **Menu Node** entry stating callbacks receive resolver-owned child Menu Nodes.
- `.changeset/render-callbacks-menu-nodes.md` — minor, breaking.

## Motivation

Builds on #475. Slice 5 made the pipeline walk Menu Nodes; the callbacks were the last place a consumer could hand the engine a def it never resolved. Slices 7 and 8 of [UI-501](https://linear.app/bazzalabs/issue/UI-501) key subpages, loaders, and dedup on `node.id`, so every node a consumer renders must be the resolver's own. Registry examples only do `nodes.map(renderNode)` / `content={nodes}` and compile unchanged (whole-repo `type-check` passes).

Review notes: adversarial review caught that the spec's "static prefix" rule (`children.slice(0, def.nodes.length)`) returns loader results after a replace-mode graft; fixed with `staticChildrenOf` plus a regression test that fails against the positional version. It also caught the subpage path converting the Menu Node back to a def and re-resolving it through an index; fixed by threading the Menu Node through.

## Tests

`data-list.test.tsx`: the raw-def double-render test now asserts one row and that the callback's `nodes[0]` is the branch's first child; new `callback nodes are resolved children with lineage` (parent, def, `definitionPath`). `command-menu-async.test.tsx`: `hands a subpage callback only static children, even after its loader replaces them` (records `nodes` on every render; verified to fail against a positional slice). Full package suite 40 files / 911 tests; whole-repo `type-check`, `check`, and `build` exit 0.

Closes [UI-507](https://linear.app/bazzalabs/issue/UI-507/render-callbacks-receive-menu-nodes-only)
