### PR TITLE
feat(popup-menu)!: key async loaders and dedup by Resolved ID; typed root loader

### DIFF
--- a/.changeset/async-dedup-resolved-id.md
+++ b/.changeset/async-dedup-resolved-id.md
@@ -1,0 +1,5 @@
+---
+'@bazza-ui/react': minor
+---
+
+**Breaking change.** Data-first async loaders are now keyed by the branch's Resolved ID, so two branches with the same `value` but different `id`s load independently; the root surface's `asyncContent` loader is exposed as `coordinator.root` instead of a `"__root__"` entry in `loaders`. `AsyncState.skippedMenus` entries are now `{ kind: 'root' } | { kind: 'branch', id }`. Deep-search deduplication keys on Resolved ID, so a custom `getResolvedId` that distinguishes same-value rows keeps both.

--- a/packages/react/src/command-menu/command-menu-async.test.tsx
+++ b/packages/react/src/command-menu/command-menu-async.test.tsx
@@ -737,4 +737,172 @@ describe('CommandMenu async data-first API', () => {
     }
     expect(seenNodes.at(-1)).toEqual([])
   })
+
+  it('same-value branches with distinct authored IDs receive distinct loader results', async () => {
+    const user = userEvent.setup()
+    const loaderA = createControllableLoader()
+    const loaderB = createControllableLoader()
+    const nodes: NodeDef[] = [
+      createSubpageDef({
+        id: 'a',
+        value: 'Status',
+        asyncNodes: {
+          type: 'static',
+          Loader: loaderA.Loader,
+          loadStrategy: 'eager',
+        },
+      }),
+      createSubpageDef({
+        id: 'b',
+        value: 'Status',
+        asyncNodes: {
+          type: 'static',
+          Loader: loaderB.Loader,
+          loadStrategy: 'eager',
+        },
+      }),
+    ]
+
+    render(
+      <DataCommandMenu
+        deepSearch={{ enabled: true, minLength: 1 }}
+        nodes={nodes}
+      />,
+    )
+    await waitForRootInputFocus()
+    await user.type(screen.getByTestId('input-root'), 'result')
+
+    await resolveLoader(loaderA, [createItemDef('a-result', 'A result')])
+    await resolveLoader(loaderB, [createItemDef('b-result', 'B result')])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('item-a-result')).toBeInTheDocument()
+      expect(screen.getByTestId('item-b-result')).toBeInTheDocument()
+    })
+    // Each result is grafted under its own branch: the deep-search row IDs are
+    // qualified by the authored branch id, not the shared value.
+    expect(screen.getByTestId('item-a-result').id).toBe('a/a-result')
+    expect(screen.getByTestId('item-b-result').id).toBe('b/b-result')
+    expect(screen.getAllByTestId('item-a-result')).toHaveLength(1)
+    expect(screen.getAllByTestId('item-b-result')).toHaveLength(1)
+  })
+
+  it('a branch with Resolved ID "__root__" and a root loader coexist', async () => {
+    const user = userEvent.setup()
+    const rootLoader = createControllableLoader()
+    const branchLoader = createControllableLoader()
+    const rootBranch = createSubpageDef({
+      id: '__root__',
+      value: 'Root-ish',
+      asyncNodes: {
+        type: 'static',
+        Loader: branchLoader.Loader,
+        loadStrategy: 'eager',
+      },
+    })
+
+    render(
+      <CommandMenu.Root defaultOpen>
+        <CommandMenu.Trigger data-testid="trigger">
+          Open commands
+        </CommandMenu.Trigger>
+        <CommandMenu.Portal>
+          <CommandMenu.Popup data-testid="dialog">
+            <CommandMenu.Surface
+              asyncContent={{
+                type: 'static',
+                Loader: rootLoader.Loader,
+                loadStrategy: 'eager',
+              }}
+              content={[rootBranch]}
+              data-testid="surface-root"
+              deepSearch={{ enabled: true, minLength: 1 }}
+            >
+              <CommandMenu.Input
+                aria-label="Search commands"
+                data-testid="input-root"
+              />
+              <CommandMenu.List data-testid="list-root">
+                <DataRows />
+              </CommandMenu.List>
+            </CommandMenu.Surface>
+          </CommandMenu.Popup>
+        </CommandMenu.Portal>
+      </CommandMenu.Root>,
+    )
+    await waitForRootInputFocus()
+    await user.type(screen.getByTestId('input-root'), 'result')
+
+    // The root result keeps the branch so the branch loader has a target.
+    await act(async () => {
+      rootLoader.resolve([
+        createItemDef('root-result', 'Root result'),
+        rootBranch,
+      ])
+      branchLoader.resolve([createItemDef('branch-result', 'Branch result')])
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('item-root-result')).toBeInTheDocument()
+      expect(screen.getByTestId('item-branch-result')).toBeInTheDocument()
+    })
+  })
+
+  it('block mode unblocks when a root-only loader resolves', async () => {
+    const user = userEvent.setup()
+    const rootLoader = createControllableLoader()
+
+    render(
+      <CommandMenu.Root defaultOpen>
+        <CommandMenu.Trigger data-testid="trigger">
+          Open commands
+        </CommandMenu.Trigger>
+        <CommandMenu.Portal>
+          <CommandMenu.Popup data-testid="dialog">
+            <CommandMenu.Surface
+              asyncContent={{
+                type: 'static',
+                Loader: rootLoader.Loader,
+                loadStrategy: 'eager',
+              }}
+              content={[]}
+              data-testid="surface-root"
+              deepSearch={{
+                enabled: true,
+                minLength: 1,
+                asyncResultBehavior: 'block',
+              }}
+            >
+              <CommandMenu.Input
+                aria-label="Search commands"
+                data-testid="input-root"
+              />
+              <CommandMenu.List data-testid="list-root">
+                <DataRows />
+              </CommandMenu.List>
+              <CommandMenu.Loading data-testid="loading-root">
+                Loading commands
+              </CommandMenu.Loading>
+            </CommandMenu.Surface>
+          </CommandMenu.Popup>
+        </CommandMenu.Portal>
+      </CommandMenu.Root>,
+    )
+    await waitForRootInputFocus()
+    await user.type(screen.getByTestId('input-root'), 'result')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading-root')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('item-root-result')).not.toBeInTheDocument()
+
+    await resolveLoader(rootLoader, [
+      createItemDef('root-result', 'Root result'),
+    ])
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-root')).not.toBeInTheDocument()
+      expect(screen.getByTestId('item-root-result')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/react/src/internal/popup-menu/data-first/__tests__/stateful-items.test.ts
+++ b/packages/react/src/internal/popup-menu/data-first/__tests__/stateful-items.test.ts
@@ -1316,9 +1316,14 @@ describe('Value Normalization', () => {
         }),
       ]
 
-      const collected = collectAsyncSubmenus(nodes)
+      const resolver = createMenuTreeResolver()
+      resolver.setContent(nodes)
+      const collected = collectAsyncSubmenus(resolver.rootNodes)
 
-      expect(collected.map((entry) => entry.id)).toEqual(['Included'])
+      expect(collected.map((entry) => entry.node.def.value)).toEqual([
+        'Included',
+      ])
+      expect(collected[0].id).toBe(resolver.getNodeForDef(nodes[0])!.id)
     })
 
     it('collectAsyncSubmenus also collects async subpages', () => {
@@ -1334,9 +1339,14 @@ describe('Value Normalization', () => {
         }),
       ]
 
-      const collected = collectAsyncSubmenus(nodes)
+      const resolver = createMenuTreeResolver()
+      resolver.setContent(nodes)
+      const collected = collectAsyncSubmenus(resolver.rootNodes)
 
-      expect(collected.map((entry) => entry.id)).toEqual(['AI Filter'])
+      expect(collected.map((entry) => entry.node.def.value)).toEqual([
+        'AI Filter',
+      ])
+      expect(collected[0].id).toBe(resolver.getNodeForDef(nodes[0])!.id)
     })
 
     it('collectAsyncSubmenus respects ancestor trigger-only hard stop', () => {
@@ -1361,7 +1371,9 @@ describe('Value Normalization', () => {
         ),
       ]
 
-      const collected = collectAsyncSubmenus(nodes)
+      const resolver = createMenuTreeResolver()
+      resolver.setContent(nodes)
+      const collected = collectAsyncSubmenus(resolver.rootNodes)
 
       expect(collected).toHaveLength(0)
     })
@@ -1475,5 +1487,58 @@ describe('Menu Node pipeline', () => {
     expect(rowNodes).toHaveLength(1)
     expect(rowNodes[0]!.node.def.value).toBe('Grafted')
     expect(rowNodes[0]!.context.breadcrumbs[0]!.menuNode).toBe(submenuNode)
+  })
+})
+
+describe('deduplicateNodes', () => {
+  it('keeps same-value rows that a custom getResolvedId distinguishes', () => {
+    const first = {
+      kind: 'item',
+      value: 'Backlog',
+      render: () => null,
+    } as ItemDef
+    const second = {
+      kind: 'item',
+      value: 'Backlog',
+      render: () => null,
+    } as ItemDef
+    const resolver = createMenuTreeResolver({
+      getResolvedId: (node) =>
+        node.def.id ?? `${node.definitionKey}-${node.index}`,
+    })
+    resolver.setContent([createSubmenuDef('status', 'Status', [first, second])])
+
+    const { displayNodes } = filterNodes({
+      query: 'backlog',
+      nodes: resolver.rootNodes,
+      highlightedId: null,
+      deepSearch: true,
+      groupSearchBehavior: 'flatten',
+    })
+    const rows = displayNodes.filter(isDisplayRowNode)
+
+    expect(rows.map((row) => row.node.def)).toEqual([first, second])
+    expect(new Set(rows.map((row) => row.node.id)).size).toBe(2)
+  })
+
+  it('collapses a loader-repeated def', () => {
+    const item = createItemDef('backlog', 'Backlog')
+    const resolver = createMenuTreeResolver()
+    resolver.setContent([createSubmenuDef('status', 'Status', [item])])
+    const submenuNode = resolver.rootNodes[0]!
+
+    resolver.graft(submenuNode, [item, item])
+    // Dedup runs in the flatten search path (its only call site).
+    const { displayNodes } = filterNodes({
+      query: 'backlog',
+      nodes: resolver.rootNodes,
+      highlightedId: null,
+      deepSearch: true,
+      groupSearchBehavior: 'flatten',
+    })
+    const rows = displayNodes.filter(isDisplayRowNode)
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.node.def).toBe(item)
   })
 })

--- a/packages/react/src/internal/popup-menu/data-first/async-coordinator.tsx
+++ b/packages/react/src/internal/popup-menu/data-first/async-coordinator.tsx
@@ -18,11 +18,14 @@ import type {
 export interface AsyncMenuState {
   /** Unique identifier for this async menu */
   id: string
-  /** Breadcrumbs path to this menu (for merging into tree) */
-  breadcrumbs: string[]
   /** The loader configuration */
   config: AsyncLoaderConfig
   /** Current loader result */
+  result: AsyncLoaderResult<NodeDef[]>
+}
+
+export interface RootAsyncMenuState {
+  config: AsyncLoaderConfig
   result: AsyncLoaderResult<NodeDef[]>
 }
 
@@ -37,6 +40,9 @@ export interface AsyncMenuCoordinatorValue {
   unregisterLoader: (id: string) => void
   /** Update loader result */
   updateLoaderResult: (id: string, result: AsyncLoaderResult<NodeDef[]>) => void
+  registerRootLoader: (state: RootAsyncMenuState) => void
+  unregisterRootLoader: () => void
+  updateRootLoaderResult: (result: AsyncLoaderResult<NodeDef[]>) => void
 
   // ---- Search Query ----
   /** Current search query from the store */
@@ -45,6 +51,8 @@ export interface AsyncMenuCoordinatorValue {
   // ---- Loader State ----
   /** All registered loaders */
   loaders: Map<string, AsyncMenuState>
+  /** The root surface's own `asyncContent` loader; `null` when none is registered. Never present in `loaders`. */
+  root: RootAsyncMenuState | null
 
   // ---- Computed State ----
   /** Any loader is currently in initial loading phase */
@@ -57,7 +65,7 @@ export interface AsyncMenuCoordinatorValue {
   isAnyRefetching: boolean
   /** All registered loaders are currently in background refetch phase */
   isAllRefetching: boolean
-  /** The root (__root__) loader is currently in initial loading phase */
+  /** The root loader is currently in initial loading phase */
   isRootLoading: boolean
   /** Static loaders are currently in initial loading phase */
   isStaticLoading: boolean
@@ -79,16 +87,16 @@ export interface AsyncMenuCoordinatorValue {
   allResolved: boolean
 
   // ---- Async Nodes ----
-  /** Get all resolved async nodes with their breadcrumbs */
-  getAsyncNodes: () => Array<{
-    id: string
-    breadcrumbs: string[]
-    nodes: NodeDef[]
-  }>
+  /** Every loader with a usable result: the root entry (if any) and one branch entry per Resolved ID. */
+  getAsyncNodes: () => Array<
+    | { kind: 'root'; nodes: NodeDef[] }
+    | { kind: 'branch'; id: string; nodes: NodeDef[] }
+  >
 
   // ---- Error Tracking ----
   /** Loaders that errored */
   erroredLoaders: Map<string, Error>
+  rootError: Error | null
 
   // ---- Aggregated State ----
   /** Get the aggregate async state for DataList */
@@ -134,11 +142,31 @@ export function AsyncMenuCoordinatorProvider(
   const [loaders, setLoaders] = React.useState<Map<string, AsyncMenuState>>(
     () => new Map(),
   )
+  const [root, setRoot] = React.useState<RootAsyncMenuState | null>(null)
 
   // Track errored loaders
   const [erroredLoaders, setErroredLoaders] = React.useState<
     Map<string, Error>
   >(() => new Map())
+  const [rootError, setRootError] = React.useState<Error | null>(null)
+
+  const registerRootLoader = React.useCallback((state: RootAsyncMenuState) => {
+    setRoot(state)
+  }, [])
+  const unregisterRootLoader = React.useCallback(() => {
+    setRoot(null)
+    setRootError(null)
+  }, [])
+  const updateRootLoaderResult = React.useCallback(
+    (result: AsyncLoaderResult<NodeDef[]>) => {
+      setRoot((prev) => (prev ? { ...prev, result } : prev))
+      // Same transitions as branch loaders: set on a real error, clear only
+      // once the loader is no longer errored.
+      if (result.isError && result.error) setRootError(result.error)
+      else if (!result.isError) setRootError(null)
+    },
+    [],
+  )
 
   // Register a loader
   const registerLoader = React.useCallback((state: AsyncMenuState) => {
@@ -198,83 +226,101 @@ export function AsyncMenuCoordinatorProvider(
 
   // Computed loading states
   const isStaticFetching = React.useMemo(() => {
+    if (root?.config.type === 'static' && root.result.isFetching) return true
     for (const [, state] of loaders) {
       if (state.config.type === 'static' && state.result.isFetching) {
         return true
       }
     }
     return false
-  }, [loaders])
+  }, [loaders, root])
 
   const isStaticLoading = React.useMemo(() => {
+    if (root?.config.type === 'static' && root.result.isLoading) return true
     for (const [, state] of loaders) {
       if (state.config.type === 'static' && state.result.isLoading) {
         return true
       }
     }
     return false
-  }, [loaders])
+  }, [loaders, root])
 
   const isStaticInitialLoading = React.useMemo(() => {
+    if (root?.config.type === 'static' && root.result.isInitialLoading)
+      return true
     for (const [, state] of loaders) {
       if (state.config.type === 'static' && state.result.isInitialLoading) {
         return true
       }
     }
     return false
-  }, [loaders])
+  }, [loaders, root])
 
   const isStaticRefetching = React.useMemo(() => {
+    if (root?.config.type === 'static' && root.result.isRefetching) return true
     for (const [, state] of loaders) {
       if (state.config.type === 'static' && state.result.isRefetching) {
         return true
       }
     }
     return false
-  }, [loaders])
+  }, [loaders, root])
 
   const isQueryFetching = React.useMemo(() => {
+    if (root?.config.type === 'query' && root.result.isFetching) return true
     for (const [, state] of loaders) {
       if (state.config.type === 'query' && state.result.isFetching) {
         return true
       }
     }
     return false
-  }, [loaders])
+  }, [loaders, root])
 
   const isQueryLoading = React.useMemo(() => {
+    if (root?.config.type === 'query' && root.result.isLoading) return true
     for (const [, state] of loaders) {
       if (state.config.type === 'query' && state.result.isLoading) {
         return true
       }
     }
     return false
-  }, [loaders])
+  }, [loaders, root])
 
   const isQueryInitialLoading = React.useMemo(() => {
+    if (root?.config.type === 'query' && root.result.isInitialLoading)
+      return true
     for (const [, state] of loaders) {
       if (state.config.type === 'query' && state.result.isInitialLoading) {
         return true
       }
     }
     return false
-  }, [loaders])
+  }, [loaders, root])
 
   const isQueryRefetching = React.useMemo(() => {
+    if (root?.config.type === 'query' && root.result.isRefetching) return true
     for (const [, state] of loaders) {
       if (state.config.type === 'query' && state.result.isRefetching) {
         return true
       }
     }
     return false
-  }, [loaders])
+  }, [loaders, root])
 
-  const isAnyFetching = isStaticFetching || isQueryFetching
-  const isAnyLoading = isStaticLoading || isQueryLoading
-  const isAnyInitialLoading = isStaticInitialLoading || isQueryInitialLoading
-  const isAnyRefetching = isStaticRefetching || isQueryRefetching
+  const isAnyFetching =
+    (root?.result.isFetching ?? false) || isStaticFetching || isQueryFetching
+  const isAnyLoading =
+    (root?.result.isLoading ?? false) || isStaticLoading || isQueryLoading
+  const isAnyInitialLoading =
+    (root?.result.isInitialLoading ?? false) ||
+    isStaticInitialLoading ||
+    isQueryInitialLoading
+  const isAnyRefetching =
+    (root?.result.isRefetching ?? false) ||
+    isStaticRefetching ||
+    isQueryRefetching
   const isAllRefetching = React.useMemo(() => {
-    if (loaders.size === 0) {
+    if (loaders.size === 0 && !root) {
       return false
     }
 
@@ -283,33 +329,33 @@ export function AsyncMenuCoordinatorProvider(
         return false
       }
     }
+    return root ? root.result.isRefetching : true
+  }, [loaders, root])
 
-    return true
-  }, [loaders])
-
-  // Only the root loader (__root__) — i.e. the DataSurface's own asyncContent.
-  // Child submenu loaders are not included; they show loading on their own triggers.
   const isRootLoading = React.useMemo(() => {
-    const rootLoader = loaders.get('__root__')
-    return rootLoader?.result.isLoading ?? false
-  }, [loaders])
+    return root?.result.isLoading ?? false
+  }, [root])
 
   const allResolved = React.useMemo(() => {
+    if (root?.result.isFetching) return false
     for (const [, state] of loaders) {
       if (state.result.isFetching) {
         return false
       }
     }
     return true
-  }, [loaders])
+  }, [loaders, root])
 
   // Get all resolved async nodes
   const getAsyncNodes = React.useCallback(() => {
-    const result: Array<{
-      id: string
-      breadcrumbs: string[]
-      nodes: NodeDef[]
-    }> = []
+    const result: Array<
+      | { kind: 'root'; nodes: NodeDef[] }
+      | { kind: 'branch'; id: string; nodes: NodeDef[] }
+    > = []
+
+    if (root?.result.data && !rootError) {
+      result.push({ kind: 'root', nodes: root.result.data })
+    }
 
     for (const [id, state] of loaders) {
       // Skip errored loaders
@@ -320,22 +366,24 @@ export function AsyncMenuCoordinatorProvider(
       // Add resolved data
       if (state.result.data) {
         result.push({
+          kind: 'branch',
           id,
-          breadcrumbs: state.breadcrumbs,
           nodes: state.result.data,
         })
       }
     }
 
     return result
-  }, [loaders, erroredLoaders])
+  }, [loaders, erroredLoaders, root, rootError])
 
   // Get aggregate async state
   const getAsyncState = React.useCallback((): AsyncState => {
-    const skippedMenus: Array<{ id: string; reason: 'error' }> = []
+    const skippedMenus: AsyncState['skippedMenus'] = []
+
+    if (rootError) skippedMenus.push({ kind: 'root', reason: 'error' })
 
     for (const [id] of erroredLoaders) {
-      skippedMenus.push({ id, reason: 'error' })
+      skippedMenus.push({ kind: 'branch', id, reason: 'error' })
     }
 
     return {
@@ -365,6 +413,7 @@ export function AsyncMenuCoordinatorProvider(
     isQueryInitialLoading,
     isQueryRefetching,
     erroredLoaders,
+    rootError,
   ])
 
   // Context value
@@ -373,8 +422,12 @@ export function AsyncMenuCoordinatorProvider(
       registerLoader,
       unregisterLoader,
       updateLoaderResult,
+      registerRootLoader,
+      unregisterRootLoader,
+      updateRootLoaderResult,
       searchQuery,
       loaders,
+      root,
       isAnyLoading,
       isAnyFetching,
       isAnyInitialLoading,
@@ -392,14 +445,19 @@ export function AsyncMenuCoordinatorProvider(
       allResolved,
       getAsyncNodes,
       erroredLoaders,
+      rootError,
       getAsyncState,
     }),
     [
       registerLoader,
       unregisterLoader,
       updateLoaderResult,
+      registerRootLoader,
+      unregisterRootLoader,
+      updateRootLoaderResult,
       searchQuery,
       loaders,
+      root,
       isAnyLoading,
       isAnyFetching,
       isAnyInitialLoading,
@@ -417,6 +475,7 @@ export function AsyncMenuCoordinatorProvider(
       allResolved,
       getAsyncNodes,
       erroredLoaders,
+      rootError,
       getAsyncState,
     ],
   )

--- a/packages/react/src/internal/popup-menu/data-first/async.ts
+++ b/packages/react/src/internal/popup-menu/data-first/async.ts
@@ -2,11 +2,11 @@
 // Async Node Collection & Merging
 // ============================================================================
 
-import { normalizeValue } from '../../listbox/utils/normalize.js'
+import { staticChildrenOf } from '../menu-tree/resolve.js'
+import type { PopupMenuNode } from '../menu-tree/types.js'
 import type {
   AsyncNodesConfig,
   IncludeInDeepSearch,
-  NodeDef,
   SubmenuDef,
   SubpageDef,
 } from './types.js'
@@ -18,12 +18,10 @@ import type {
  * Info about an async branch node (submenu/subpage) for registration.
  */
 export interface AsyncSubmenuInfo {
-  /** Unique identifier (uses node value and breadcrumbs) */
+  /** The branch's Resolved ID — the loader key. */
   id: string
-  /** Breadcrumbs path to this branch node */
-  breadcrumbs: string[]
-  /** The branch node definition */
-  node: SubmenuDef | SubpageDef
+  /** The branch Menu Node (graft target and async-state key). */
+  node: PopupMenuNode<SubmenuDef | SubpageDef>
   /** The async configuration */
   config: AsyncNodesConfig
 }
@@ -32,25 +30,23 @@ export interface AsyncSubmenuInfo {
  * Collects all async branch nodes from a node tree.
  * Recursively traverses groups and branches to find all async configurations.
  */
-export function collectAsyncSubmenus(
-  nodes: NodeDef[],
-  breadcrumbs: string[] = [],
+function collectAsyncSubmenusRaw(
+  nodes: readonly PopupMenuNode[],
   includeInDeepSearch: IncludeInDeepSearch = true,
   descendantsIncluded = true,
 ): AsyncSubmenuInfo[] {
   const result: AsyncSubmenuInfo[] = []
 
   for (const node of nodes) {
-    if (node.kind === 'separator') {
+    if (node.def.kind === 'separator') {
       continue
     }
 
-    if (node.kind === 'group') {
+    if (node.def.kind === 'group') {
       // Recurse into groups
       result.push(
-        ...collectAsyncSubmenus(
-          node.nodes,
-          breadcrumbs,
+        ...collectAsyncSubmenusRaw(
+          staticChildrenOf(node),
           includeInDeepSearch,
           descendantsIncluded,
         ),
@@ -58,13 +54,12 @@ export function collectAsyncSubmenus(
       continue
     }
 
-    if (node.kind === 'radio-group') {
-      if (node.hidden) continue
+    if (node.def.kind === 'radio-group') {
+      if (node.def.hidden) continue
       // Recurse into radio groups
       result.push(
-        ...collectAsyncSubmenus(
-          node.nodes,
-          breadcrumbs,
+        ...collectAsyncSubmenusRaw(
+          staticChildrenOf(node),
           includeInDeepSearch,
           descendantsIncluded,
         ),
@@ -72,34 +67,30 @@ export function collectAsyncSubmenus(
       continue
     }
 
-    if (node.kind === 'submenu' || node.kind === 'subpage') {
-      if (node.hidden) continue
+    if (node.def.kind === 'submenu' || node.def.kind === 'subpage') {
+      if (node.def.hidden) continue
 
-      const branchIncludeMode = node.includeInDeepSearch ?? includeInDeepSearch
+      const branchIncludeMode =
+        node.def.includeInDeepSearch ?? includeInDeepSearch
       const shouldIncludeBranchDescendants =
         descendantsIncluded &&
         branchIncludeMode === true &&
-        node.deepSearch !== false
+        node.def.deepSearch !== false
 
       // If this branch has async nodes, add it to the result
-      if (node.asyncNodes && shouldIncludeBranchDescendants) {
-        // Must match getAsyncLoaderIdForBranch's value-only path-key scheme.
-        const id = [...breadcrumbs, normalizeValue(node.value)].join('.')
+      if (node.def.asyncNodes && shouldIncludeBranchDescendants) {
         result.push({
-          id,
-          breadcrumbs,
-          node,
-          config: node.asyncNodes,
+          id: node.id,
+          node: node as PopupMenuNode<SubmenuDef | SubpageDef>,
+          config: node.def.asyncNodes,
         })
       }
 
       // Recurse into branch node's static nodes
-      if (node.nodes && shouldIncludeBranchDescendants) {
-        const childBreadcrumbs = [...breadcrumbs, normalizeValue(node.value)]
+      if (shouldIncludeBranchDescendants) {
         result.push(
-          ...collectAsyncSubmenus(
-            node.nodes,
-            childBreadcrumbs,
+          ...collectAsyncSubmenusRaw(
+            staticChildrenOf(node),
             includeInDeepSearch,
             true,
           ),
@@ -149,4 +140,29 @@ export function shouldLoadEagerly(config: AsyncNodesConfig): boolean {
 
   // Both static and query loaders can still opt into legacy eager strategy.
   return config.loadStrategy === 'eager'
+}
+
+/**
+ * Collects all async branch nodes from a Menu Node tree, one entry per
+ * Resolved ID. Recursively traverses groups and branches (static children
+ * only) to find every async configuration. A loader result that repeats an
+ * authored branch def yields the same Resolved ID and is collapsed.
+ */
+export function collectAsyncSubmenus(
+  nodes: readonly PopupMenuNode[],
+  includeInDeepSearch: IncludeInDeepSearch = true,
+  descendantsIncluded = true,
+): AsyncSubmenuInfo[] {
+  const seen = new Set<string>()
+  const result: AsyncSubmenuInfo[] = []
+  for (const info of collectAsyncSubmenusRaw(
+    nodes,
+    includeInDeepSearch,
+    descendantsIncluded,
+  )) {
+    if (seen.has(info.id)) continue
+    seen.add(info.id)
+    result.push(info)
+  }
+  return result
 }

--- a/packages/react/src/internal/popup-menu/data-first/data-list.tsx
+++ b/packages/react/src/internal/popup-menu/data-first/data-list.tsx
@@ -20,10 +20,7 @@ import { useMaybeSubpageStack } from '../contexts/subpage-stack-context.js'
 import { useResolution } from '../hooks/use-resolution.js'
 import { staticChildrenOf } from '../menu-tree/resolve.js'
 import type { PopupMenuNode } from '../menu-tree/types.js'
-import {
-  type AsyncMenuState,
-  useAsyncMenuCoordinator,
-} from './async-coordinator.js'
+import { useAsyncMenuCoordinator } from './async-coordinator.js'
 import {
   DataListContext,
   type RenderNodeFn,
@@ -56,9 +53,7 @@ import {
 } from './types.js'
 import {
   type AsyncSubmenuInfo,
-  collectAsyncSubmenus,
   filterNodes,
-  getAsyncLoaderIdForBranch,
   shouldLoadEagerly,
 } from './utils.js'
 
@@ -272,7 +267,7 @@ function AsyncLoaderRenderer({
   enabled,
 }: AsyncLoaderRendererProps) {
   const coordinator = useAsyncMenuCoordinator()
-  const { config, id, breadcrumbs } = info
+  const { config, id } = info
   const Loader = config.Loader
 
   const queryExecution = React.useMemo(() => {
@@ -297,8 +292,8 @@ function AsyncLoaderRenderer({
     <Loader query={effectiveQuery} enabled={shouldFetch}>
       {(result) => (
         <AsyncLoaderResultHandler
+          kind="branch"
           id={id}
-          breadcrumbs={breadcrumbs}
           config={config}
           result={result}
           coordinator={coordinator}
@@ -308,9 +303,10 @@ function AsyncLoaderRenderer({
   )
 }
 
-interface AsyncLoaderResultHandlerProps {
-  id: string
-  breadcrumbs: string[]
+type AsyncLoaderResultHandlerProps = (
+  | { kind: 'root'; id?: undefined }
+  | { kind: 'branch'; id: string }
+) & {
   config: AsyncNodesConfig
   result: AsyncLoaderResult<NodeDef[]>
   coordinator: ReturnType<typeof useAsyncMenuCoordinator>
@@ -321,15 +317,14 @@ interface AsyncLoaderResultHandlerProps {
  * This is a separate component to avoid re-rendering the Loader on every result change.
  */
 function AsyncLoaderResultHandler({
+  kind,
   id,
-  breadcrumbs,
   config,
   result,
   coordinator,
 }: AsyncLoaderResultHandlerProps) {
   // Use refs to hold the latest values without causing re-renders
   // This is critical because coordinator changes on every state update (new Map)
-  const breadcrumbsRef = React.useRef(breadcrumbs)
   const configRef = React.useRef(config)
   const coordinatorRef = React.useRef(coordinator)
   const resultRef = React.useRef(result)
@@ -355,7 +350,6 @@ function AsyncLoaderResultHandler({
   } | null>(null)
 
   // Keep refs up to date
-  breadcrumbsRef.current = breadcrumbs
   configRef.current = config
   coordinatorRef.current = coordinator
   resultRef.current = result
@@ -367,19 +361,24 @@ function AsyncLoaderResultHandler({
     const coord = coordinatorRef.current
     if (!coord) return
 
-    const state: AsyncMenuState = {
-      id,
-      breadcrumbs: breadcrumbsRef.current,
-      config: configRef.current,
-      result: resultRef.current,
+    if (kind === 'root') {
+      coord.registerRootLoader({
+        config: configRef.current,
+        result: resultRef.current,
+      })
+    } else {
+      coord.registerLoader({
+        id,
+        config: configRef.current,
+        result: resultRef.current,
+      })
     }
-
-    coord.registerLoader(state)
 
     return () => {
-      coord.unregisterLoader(id)
+      if (kind === 'root') coord.unregisterRootLoader()
+      else coord.unregisterLoader(id)
     }
-  }, [id]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [kind, id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update result when meaningful values change
   // IMPORTANT: Depend on individual result values, not the result object reference.
@@ -429,9 +428,11 @@ function AsyncLoaderResultHandler({
         hasFetched: result.hasFetched,
         error: result.error,
       }
-      coord.updateLoaderResult(id, result)
+      if (kind === 'root') coord.updateRootLoaderResult(result)
+      else coord.updateLoaderResult(id, result)
     }
   }, [
+    kind,
     id,
     result.data,
     result.status,
@@ -490,8 +491,7 @@ function RootAsyncLoader({ query }: RootAsyncLoaderProps) {
     <Loader query={effectiveQuery} enabled={shouldFetch}>
       {(result) => (
         <AsyncLoaderResultHandler
-          id="__root__"
-          breadcrumbs={[]}
+          kind="root"
           config={asyncContent as AsyncNodesConfig}
           result={result}
           coordinator={coordinator}
@@ -552,24 +552,16 @@ export const DataListInner = React.forwardRef<
   // Get coordinator for async state
   const coordinator = useAsyncMenuCoordinator()
 
-  // Collect async submenus from content
-  const asyncSubmenus = React.useMemo(
-    () => collectAsyncSubmenus(content, [], includeInDeepSearch),
-    [content, includeInDeepSearch],
-  )
-
   // Determine if deep search is active
   const minLength = deepSearchConfig.minLength ?? 0
   const isDeepSearchActive =
     deepSearchConfig.enabled !== false && normalizedSearch.length >= minLength
 
-  // Determine which async loaders should be rendered
-  const shouldRenderAsyncLoaders =
-    isDeepSearchActive ||
-    asyncSubmenus.some((s) => shouldLoadEagerly(s.config)) ||
-    (asyncContent && asyncContent.loadStrategy === 'eager')
-
-  const { nodes: resolvedNodes, graftVersion } = useResolution({
+  const {
+    nodes: resolvedNodes,
+    graftVersion,
+    asyncSubmenus,
+  } = useResolution({
     resolver,
     content,
     asyncContent,
@@ -577,8 +569,14 @@ export const DataListInner = React.forwardRef<
     graftParent,
     isSubpageSurface,
     isResolutionRoot,
-    asyncSubmenus,
+    includeInDeepSearch,
   })
+
+  // Determine which async loaders should be rendered
+  const shouldRenderAsyncLoaders =
+    isDeepSearchActive ||
+    asyncSubmenus.some((s) => shouldLoadEagerly(s.config)) ||
+    (asyncContent && asyncContent.loadStrategy === 'eager')
 
   // Publish the resolved-nodes slot for sibling subpages. Not withdrawn on
   // unmount: the root list unmounts while a subpage is active, and the
@@ -634,7 +632,8 @@ export const DataListInner = React.forwardRef<
       result.isDeepSearching &&
       hasAsyncSources &&
       coordinator !== null &&
-      (coordinator.loaders.size < expectedAsyncLoaderCount ||
+      (coordinator.loaders.size + (coordinator.root ? 1 : 0) <
+        expectedAsyncLoaderCount ||
         coordinator.isAnyLoading)
 
     let displayNodesToRender = result.displayNodes
@@ -753,25 +752,23 @@ export const DataListInner = React.forwardRef<
 
       const id = resolved.id
 
-      const getBranchAsyncState = (branchNode: SubmenuDef | SubpageDef) => {
-        if (!branchNode.asyncNodes || !coordinator) {
+      const getBranchAsyncState = (
+        branchNode: PopupMenuNode<SubmenuDef | SubpageDef>,
+      ) => {
+        if (!branchNode.def.asyncNodes || !coordinator) {
           return undefined
         }
 
-        const asyncLoaderId = getAsyncLoaderIdForBranch(
-          branchNode,
-          context.breadcrumbs,
-        )
-        const asyncResult = coordinator.loaders.get(asyncLoaderId)
+        const asyncResult = coordinator.loaders.get(branchNode.id)
 
         if (!asyncResult) {
           return undefined
         }
 
         const isBelowMinLength =
-          branchNode.asyncNodes.type === 'query'
+          branchNode.def.asyncNodes.type === 'query'
             ? resolveQueryExecutionState(
-                branchNode.asyncNodes,
+                branchNode.def.asyncNodes,
                 normalizedSearch,
               ).isBelowMinLength
             : false
@@ -895,7 +892,9 @@ export const DataListInner = React.forwardRef<
         // For submenus, provide the nodes and a recursive renderNode function
         // Note: We pass the resolved id to the submenu trigger so it registers with the
         // correct ID for keyboard navigation during deep search
-        const submenuAsyncState = getBranchAsyncState(node)
+        const submenuAsyncState = getBranchAsyncState(
+          resolved as PopupMenuNode<SubmenuDef | SubpageDef>,
+        )
 
         // Static nodes only - async content is handled by the submenu's own DataSurface
         const staticChildren = staticChildrenOf(resolved)
@@ -1054,7 +1053,9 @@ export const DataListInner = React.forwardRef<
       }
 
       if (node.kind === 'subpage') {
-        const subpageAsyncState = getBranchAsyncState(node)
+        const subpageAsyncState = getBranchAsyncState(
+          resolved as PopupMenuNode<SubmenuDef | SubpageDef>,
+        )
         const pageId = resolved.id
 
         return (
@@ -1316,14 +1317,16 @@ export const DataListInner = React.forwardRef<
         isQueryLoading: false,
         isQueryInitialLoading: false,
         isQueryRefetching: false,
-        skippedMenus: [] as Array<{
-          id: string
-          reason: 'error'
-        }>,
+        skippedMenus: [],
       }
     }
     return coordinator.getAsyncState()
-  }, [coordinator, coordinator?.loaders, coordinator?.erroredLoaders])
+  }, [
+    coordinator,
+    coordinator?.loaders,
+    coordinator?.erroredLoaders,
+    coordinator?.root,
+  ])
 
   // Build children state
   const childrenState: DataListChildrenState = React.useMemo(

--- a/packages/react/src/internal/popup-menu/data-first/data-subpages.tsx
+++ b/packages/react/src/internal/popup-menu/data-first/data-subpages.tsx
@@ -24,7 +24,6 @@ import type {
   SubmenuDef,
   SubpageDef,
 } from './types.js'
-import { getAsyncLoaderIdForBranch } from './utils.js'
 
 interface QueryExecutionState {
   effectiveQuery: string
@@ -86,17 +85,16 @@ function resolveQueryExecutionState(
 }
 
 function getBranchAsyncState(
-  node: SubmenuDef | SubpageDef,
-  breadcrumbs: BreadcrumbNode[],
+  menuNode: PopupMenuNode<SubmenuDef | SubpageDef>,
   searchQuery: string,
   coordinator: ReturnType<typeof useAsyncMenuCoordinator>,
 ): AsyncRenderState | undefined {
+  const node = menuNode.def
   if (!node.asyncNodes || !coordinator) {
     return undefined
   }
 
-  const asyncLoaderId = getAsyncLoaderIdForBranch(node, breadcrumbs)
-  const asyncResult = coordinator.loaders.get(asyncLoaderId)
+  const asyncResult = coordinator.loaders.get(menuNode.id)
 
   if (!asyncResult) {
     return undefined
@@ -323,8 +321,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
 
         if (rowNode.kind === 'submenu') {
           const submenuAsyncState = getBranchAsyncState(
-            rowNode,
-            rowContext.breadcrumbs,
+            rowMenuNode as PopupMenuNode<SubmenuDef>,
             searchQuery,
             coordinator,
           )
@@ -466,8 +463,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
         if (rowNode.kind !== 'subpage') return null
 
         const subpageAsyncState = getBranchAsyncState(
-          rowNode,
-          rowContext.breadcrumbs,
+          rowMenuNode as PopupMenuNode<SubpageDef>,
           searchQuery,
           coordinator,
         )
@@ -566,8 +562,7 @@ export function DataSubpagesContent(props: DataSubpagesContentProps) {
                 value: node.value,
                 disabled: node.disabled ?? false,
                 async: getBranchAsyncState(
-                  node,
-                  context.breadcrumbs,
+                  resolved as PopupMenuNode<SubpageDef>,
                   searchQuery,
                   coordinator,
                 ),

--- a/packages/react/src/internal/popup-menu/data-first/path-ids.ts
+++ b/packages/react/src/internal/popup-menu/data-first/path-ids.ts
@@ -2,8 +2,8 @@
 // Path and ID Helpers
 // ============================================================================
 
-import { normalizeValue, slugify } from '../../listbox/utils/normalize.js'
-import type { BreadcrumbNode, SubmenuDef, SubpageDef } from './types.js'
+import { slugify } from '../../listbox/utils/normalize.js'
+import type { BreadcrumbNode } from './types.js'
 
 // ============================================================================
 /**
@@ -30,20 +30,4 @@ export function computeDefPath(
       .map((b) => b.id ?? slugify(b.value)),
     id ?? slugify(value),
   ]
-}
-
-/**
- * Path key for a branch's async loader. **Value-only by design** — breadcrumb
- * and leaf `value`s, normalized and dot-joined; explicit `id`s are deliberately
- * ignored. Must stay consistent with the key computations inside
- * `collectAsyncSubmenus` and `mergeAsyncNodesIntoTree`.
- */
-export function getAsyncLoaderIdForBranch(
-  node: SubmenuDef | SubpageDef,
-  breadcrumbs: BreadcrumbNode[],
-): string {
-  return [
-    ...breadcrumbs.map((breadcrumb) => normalizeValue(breadcrumb.value)),
-    normalizeValue(node.value),
-  ].join('.')
 }

--- a/packages/react/src/internal/popup-menu/data-first/sort.ts
+++ b/packages/react/src/internal/popup-menu/data-first/sort.ts
@@ -2,7 +2,6 @@
 // Sort Nodes
 // ============================================================================
 
-import { normalizeValue } from '../../listbox/utils/normalize.js'
 import type { DisplayRowNode, ScoredNode } from './types.js'
 
 // Sort Nodes
@@ -130,24 +129,14 @@ export function partitionByKind(nodes: ScoredNode[]): ScoredNode[] {
   return result
 }
 
-/**
- * Deduplicates nodes by their composite ID (breadcrumb segments + node ID/value).
- * This handles the case where the same node appears multiple times in the tree.
- * Values are normalized (trimmed) for consistent deduplication.
- */
+/** Deduplicates scored rows by Resolved ID. A row can reach the flat list twice when a loader result repeats a def already present under the same branch. */
 export function deduplicateNodes(nodes: ScoredNode[]): ScoredNode[] {
   const seen = new Set<string>()
   const result: ScoredNode[] = []
 
   for (const scoredNode of nodes) {
-    const compositeId = [
-      ...scoredNode.breadcrumbs.map(
-        (breadcrumb) => breadcrumb.id ?? normalizeValue(breadcrumb.value),
-      ),
-      scoredNode.node.def.id ?? normalizeValue(scoredNode.node.def.value),
-    ].join('.')
-    if (!seen.has(compositeId)) {
-      seen.add(compositeId)
+    if (!seen.has(scoredNode.node.id)) {
+      seen.add(scoredNode.node.id)
       result.push(scoredNode)
     }
   }

--- a/packages/react/src/internal/popup-menu/data-first/types.ts
+++ b/packages/react/src/internal/popup-menu/data-first/types.ts
@@ -284,7 +284,10 @@ export interface AsyncState {
   isQueryRefetching: boolean
 
   /** Menus that failed (skipped from results) */
-  skippedMenus: Array<{ id: string; reason: 'error' }>
+  skippedMenus: Array<
+    | { kind: 'root'; reason: 'error' }
+    | { kind: 'branch'; id: string; reason: 'error' }
+  >
 }
 
 // ============================================================================

--- a/packages/react/src/internal/popup-menu/data-first/utils.ts
+++ b/packages/react/src/internal/popup-menu/data-first/utils.ts
@@ -12,10 +12,7 @@ export {
 export { getBrowseNodesFlatten, getBrowseNodesPreserve } from './browse.js'
 export { buildDisplayRowNodes } from './display.js'
 export { flattenNodes, getSupportedTreeChildren } from './flatten.js'
-export {
-  computeDefPath,
-  getAsyncLoaderIdForBranch,
-} from './path-ids.js'
+export { computeDefPath } from './path-ids.js'
 export type { FilterNodesOptions } from './pipeline.js'
 export { filterNodes } from './pipeline.js'
 export { scoreNodes } from './score.js'

--- a/packages/react/src/internal/popup-menu/hooks/use-resolution.ts
+++ b/packages/react/src/internal/popup-menu/hooks/use-resolution.ts
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import type { AsyncSubmenuInfo } from '../data-first/async.js'
+import { collectAsyncSubmenus } from '../data-first/async.js'
 import type { AsyncMenuCoordinatorValue } from '../data-first/async-coordinator.js'
 import type {
   AsyncLoaderConfig,
@@ -20,7 +21,7 @@ export interface UseResolutionOptions {
   graftParent: PopupMenuNode | null
   isSubpageSurface: boolean
   isResolutionRoot: boolean
-  asyncSubmenus: readonly AsyncSubmenuInfo[]
+  includeInDeepSearch: boolean | 'trigger-only'
 }
 
 export interface ResolutionResult {
@@ -33,6 +34,7 @@ export interface ResolutionResult {
   nodes: readonly PopupMenuNode[]
   /** Increments once per loader-effect run that grafted anything anywhere in this list's subtree. */
   graftVersion: number
+  asyncSubmenus: readonly AsyncSubmenuInfo[]
 }
 
 export function useResolution({
@@ -43,7 +45,7 @@ export function useResolution({
   graftParent,
   isSubpageSurface,
   isResolutionRoot,
-  asyncSubmenus,
+  includeInDeepSearch,
 }: UseResolutionOptions): ResolutionResult {
   React.useMemo(() => {
     if (!resolver || isSubpageSurface) return
@@ -70,10 +72,36 @@ export function useResolution({
     ? (graftParent ?? subpageStaticNodes[0]?.parent ?? null)
     : null
 
+  // Read after the static phase so a `content` change is visible in the
+  // same render (the static phase can replace `rootNodes` / `children`).
   const [graftVersion, setGraftVersion] = React.useState(0)
-  const previousBranchesRef = React.useRef<Set<SubmenuDef | SubpageDef>>(
-    new Set(),
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on `content` and `graftVersion` (the resolution inputs), not on resolver fields
+  const staticNodes = React.useMemo(
+    () =>
+      isSubpageSurface
+        ? (subpageBranch?.children ?? subpageStaticNodes)
+        : graftParent
+          ? graftParent.children
+          : isResolutionRoot && resolver
+            ? resolver.rootNodes
+            : [],
+    [
+      isSubpageSurface,
+      subpageBranch,
+      subpageStaticNodes,
+      graftParent,
+      resolver,
+      isResolutionRoot,
+      content,
+      graftVersion,
+    ],
   )
+  const asyncSubmenus = React.useMemo(
+    () => collectAsyncSubmenus(staticNodes, includeInDeepSearch),
+    [staticNodes, includeInDeepSearch],
+  )
+
+  const previousBranchesRef = React.useRef<Set<PopupMenuNode>>(new Set())
   // biome-ignore lint/correctness/useExhaustiveDependencies: ADR-0002 — the loader phase is keyed on the coordinator's loader map (the true input), not the coordinator object or its stable callbacks
   React.useEffect(() => {
     if (!resolver || !coordinator) return
@@ -84,7 +112,13 @@ export function useResolution({
     // Menu Tree. The resolver's reference fast path and structural
     // short-circuit make the unchanged cases free.
     const results = new Map(
-      coordinator.getAsyncNodes().map((entry) => [entry.id, entry.nodes]),
+      coordinator
+        .getAsyncNodes()
+        .filter(
+          (entry): entry is { kind: 'branch'; id: string; nodes: NodeDef[] } =>
+            entry.kind === 'branch',
+        )
+        .map((entry) => [entry.id, entry.nodes]),
     )
     let changed = false
     const graft = (parent: PopupMenuNode | null, defs: readonly NodeDef[]) => {
@@ -94,7 +128,9 @@ export function useResolution({
       changed ||= before !== parent.children
     }
 
-    const rootResult = results.get('__root__')
+    const rootResult = coordinator
+      .getAsyncNodes()
+      .find((entry) => entry.kind === 'root')?.nodes
     if (isSubpageSurface && subpageBranch) {
       // The subpage's own loader (`asyncContent`) grafts under its branch with
       // the same replace/append rule as a root list.
@@ -124,26 +160,26 @@ export function useResolution({
 
     // Branches that left the async set since the last run are restored to
     // their static children so an unregistered loader's result is withdrawn.
-    const current = new Set(asyncSubmenus.map((info) => info.node))
+    const current = new Set<PopupMenuNode>(
+      asyncSubmenus.map((info) => info.node as PopupMenuNode),
+    )
     for (const node of previousBranchesRef.current) {
       if (current.has(node)) continue
-      const branch = resolver.getNodeForDef(node)
-      if (branch) graft(branch, node.nodes ?? [])
+      graft(node, (node.def as SubmenuDef | SubpageDef).nodes ?? [])
     }
     previousBranchesRef.current = current
 
     for (const info of asyncSubmenus) {
-      const branch = resolver.getNodeForDef(info.node)
-      if (!branch) continue
       const loaded = results.get(info.id)
-      const staticChildren = info.node.nodes ?? []
-      graft(branch, loaded ? [...staticChildren, ...loaded] : staticChildren)
+      const staticChildren = info.node.def.nodes ?? []
+      graft(info.node, loaded ? [...staticChildren, ...loaded] : staticChildren)
     }
     if (changed) setGraftVersion((version) => version + 1)
   }, [
     resolver,
     coordinator?.loaders,
     coordinator?.erroredLoaders,
+    coordinator?.root,
     content,
     asyncContent,
     asyncSubmenus,
@@ -177,5 +213,5 @@ export function useResolution({
       graftVersion,
     ],
   )
-  return { nodes, graftVersion }
+  return { nodes, graftVersion, asyncSubmenus }
 }


### PR DESCRIPTION
## Summary

Removes the last two identity schemes. Async loader registration is keyed by the branch's **Resolved ID** (`node.id`) instead of a value-only dot path, and the root surface's own `asyncContent` loader lives in a typed `coordinator.root` slot instead of under the reserved key `"__root__"` — so two branches with the same `value` but different `id`s load independently and any string is a valid branch ID. Deep-search deduplication keys on `node.id`, so a custom `getResolvedId` that distinguishes same-value rows keeps both.

## Changes

- `data-first/async.ts` — `collectAsyncSubmenus` walks Menu Nodes (static children via `staticChildrenOf`, so grafted results never contribute loaders), returns `{ id: node.id, node, config }`, and collapses to one entry per Resolved ID. The `breadcrumbs` parameter/field is gone.
- `hooks/use-resolution.ts` — computes `asyncSubmenus` from its own post-static-phase `nodes` (keyed on `content` and `graftVersion`) and exposes it; grafts under `info.node` directly (no `getNodeForDef`); finds the root entry by `kind === 'root'`; `coordinator?.root` in the effect deps. The slice-4 withdrawal/restoration/subpage behaviours are kept.
- `data-first/async-coordinator.tsx` — `root: RootAsyncMenuState | null` with `registerRootLoader` / `unregisterRootLoader` / `updateRootLoaderResult` and a `rootError`; every aggregate flag folds `root` in; `getAsyncNodes` returns `{ kind: 'root' } | { kind: 'branch', id }` entries; `skippedMenus` uses the same discriminant; `AsyncMenuState.breadcrumbs` deleted.
- `data-list.tsx` / `data-subpages.tsx` — `AsyncLoaderResultHandler` takes a discriminated `{ kind: 'root' } | { kind: 'branch', id }` prop (a branch id of `""` is valid); `getBranchAsyncState` takes the Menu Node and looks up `loaders.get(node.id)`; the block-mode gate counts `loaders.size + (root ? 1 : 0)`.
- `data-first/path-ids.ts` — `getAsyncLoaderIdForBranch` deleted (and from the barrels).
- `data-first/sort.ts` — `deduplicateNodes` keys on `scoredNode.node.id`.
- `.changeset/async-dedup-resolved-id.md` — minor, breaking.

## Motivation

Builds on #477. After it, the only strings still computed from defs and paths rather than read from the Menu Tree were the loader key and the dedup composite key — both of which ignored authored `id`s, so two same-value branches shared a loader and a custom `getResolvedId` could not keep two same-value rows. With this PR every subsystem in [UI-501](https://linear.app/bazzalabs/issue/UI-501) addresses a node by `node.id`. The glossary's *Removed vocabulary* already names both schemes.

Review notes: adversarial review caught that a branch id of `""` was rejected by a truthiness check, that a loader repeating an authored branch def could double-count in block mode (collapsed by Resolved ID), that loader collection did not track grafts (`graftVersion` added to its key), and that the root error transition differed from the branch one (now identical three-way logic).

## Tests

`command-menu-async.test.tsx`: `same-value branches with distinct authored IDs receive distinct loader results` (asserts qualified row ids `a/a-result` / `b/b-result`), `a branch with Resolved ID "__root__" and a root loader coexist`, `block mode unblocks when a root-only loader resolves`. `stateful-items.test.ts`: the three `collectAsyncSubmenus` tests rewritten to Menu Nodes (same expectations plus `id === node.id`), and a `deduplicateNodes` block — `keeps same-value rows that a custom getResolvedId distinguishes` and `collapses a loader-repeated def` (both verified to fail against value-keyed dedup; both run the `flatten` search path, dedup's only call site). The existing sequential two-loader block-mode test and the `duplicate local IDs` tests pass unchanged. Full package suite 39 files / 911 tests; whole-repo `type-check`, `check`, and `build` exit 0.

Closes [UI-509](https://linear.app/bazzalabs/issue/UI-509/key-async-loaders-and-dedup-by-resolved-id-typed-root-loader)
